### PR TITLE
Focal plane transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__
 */cython_version.py
 htmlcov
 .coverage
+.cache
 MANIFEST
 
 # Sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ install:
     - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
 
     # COVERAGE DEPENDENCIES
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage==3.7.1 coveralls; fi
 
 script:
    - python setup.py $SETUP_CMD

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,4 +1,10 @@
 API Reference
 =============
 
-.. automodapi:: specsim
+.. automodapi:: specsim.atmosphere
+.. automodapi:: specsim.driver
+.. automodapi:: specsim.instrument
+.. automodapi:: specsim.quick
+.. automodapi:: specsim.sources
+.. automodapi:: specsim.spectrum
+.. automodapi:: specsim.transform

--- a/specsim/__init__.py
+++ b/specsim/__init__.py
@@ -12,8 +12,9 @@ from ._astropy_init import *
 
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
-    pass
-    #from .spectrum import WavelengthFunction,SpectralFluxDensity
-    #from .instrument import Instrument
-    #from .atmosphere import Atmosphere
-    #from .quick import Quick
+    import atmosphere
+    import instrument
+    import quick
+    import sources
+    import spectrum
+    import transform

--- a/specsim/__init__.py
+++ b/specsim/__init__.py
@@ -12,7 +12,8 @@ from ._astropy_init import *
 
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
-    from .spectrum import WavelengthFunction,SpectralFluxDensity
-    from .instrument import Instrument
-    from .atmosphere import Atmosphere
-    from .quick import Quick
+    pass
+    #from .spectrum import WavelengthFunction,SpectralFluxDensity
+    #from .instrument import Instrument
+    #from .atmosphere import Atmosphere
+    #from .quick import Quick

--- a/specsim/atmosphere.py
+++ b/specsim/atmosphere.py
@@ -8,7 +8,8 @@ import os.path
 import numpy as np
 import scipy.interpolate
 
-from . import WavelengthFunction,SpectralFluxDensity
+import specsim.spectrum
+
 
 class Atmosphere(object):
     def __init__(self,skySpectrumFilename=None,zenithExtinctionFilename=None,
@@ -35,6 +36,8 @@ class Atmosphere(object):
             zenithExtinctionFilename = os.path.join(basePath,
                 'data','spectra','ZenithExtinction-KPNO.dat')
         # Load the tabulated sky spectrum.
-        self.skySpectrum = SpectralFluxDensity.loadFromTextFile(skySpectrumFilename)
+        self.skySpectrum =\
+            specsim.spectrum.SpectralFluxDensity.loadFromTextFile(skySpectrumFilename)
         # Load the tabulated zenith extinction coefficients.
-        self.zenithExtinction = WavelengthFunction.loadFromTextFile(zenithExtinctionFilename)
+        self.zenithExtinction =\
+            specsim.spectrum.WavelengthFunction.loadFromTextFile(zenithExtinctionFilename)

--- a/specsim/driver.py
+++ b/specsim/driver.py
@@ -20,9 +20,7 @@ import numpy as np
 
 from astropy.utils.compat import argparse
 
-import specsim.spectrum
-import specsim.atmosphere
-import specsim.quick
+import specsim
 
 
 # This is a setup.py entry-point, not a standalone script.

--- a/specsim/driver.py
+++ b/specsim/driver.py
@@ -20,7 +20,10 @@ import numpy as np
 
 from astropy.utils.compat import argparse
 
-import specsim as sim
+import specsim.spectrum
+import specsim.atmosphere
+import specsim.quick
+
 
 # This is a setup.py entry-point, not a standalone script.
 # See http://astropy.readthedocs.org/en/latest/development/scripts.html
@@ -92,7 +95,7 @@ def main(args=None):
     if not os.path.isfile(args.infile):
         print('No such infile: %s' % args.infile)
         return -1
-    srcSpectrum = sim.SpectralFluxDensity.loadFromTextFile(args.infile,
+    srcSpectrum = specsim.spectrum.SpectralFluxDensity.loadFromTextFile(args.infile,
         wavelengthColumn=args.infile_wavecol,valuesColumn=args.infile_fluxcol,
         extrapolatedValue=(0. if args.truncated else None))
 
@@ -127,10 +130,10 @@ def main(args=None):
     print(specSummary)
 
     # Create the default atmosphere for the requested sky conditions.
-    atmosphere = sim.Atmosphere(skyConditions=args.sky,basePath=os.environ['SPECSIM_MODEL'])
+    atmosphere = specsim.atmosphere.Atmosphere(skyConditions=args.sky,basePath=os.environ['SPECSIM_MODEL'])
 
     # Create a quick simulator using the default instrument model.
-    qsim = sim.Quick(atmosphere=atmosphere,basePath=os.environ['SPECSIM_MODEL'])
+    qsim = specsim.quick.Quick(atmosphere=atmosphere,basePath=os.environ['SPECSIM_MODEL'])
 
     # Initialize the simulation wavelength grid to use.
     if args.verbose:

--- a/specsim/quick.py
+++ b/specsim/quick.py
@@ -12,7 +12,10 @@ from scipy.special import exp10
 from astropy import constants as const
 from astropy import units
 
-from . import Atmosphere,Instrument,SpectralFluxDensity
+import specsim.spectrum
+import specsim.atmosphere
+import specsim.instrument
+
 
 class QuickCamera(object):
     """
@@ -134,8 +137,10 @@ class Quick(object):
     using the specified base path.
     """
     def __init__(self,atmosphere=None,instrument=None,basePath=''):
-        self.atmosphere = atmosphere if atmosphere else Atmosphere(basePath=basePath)
-        self.instrument = instrument if instrument else Instrument(basePath=basePath)
+        self.atmosphere = (atmosphere if atmosphere else
+            specsim.atmosphere.Atmosphere(basePath=basePath))
+        self.instrument = (instrument if instrument else
+            specsim.instrument.Instrument(basePath=basePath))
 
         # Precompute the physical constant h*c in units of erg*Ang.
         self.hc = const.h.to(units.erg*units.s)*const.c.to(units.angstrom/units.s)
@@ -287,8 +292,8 @@ class Quick(object):
 
         # Convert the source to a SpectralFluxDensity if necessary, setting the flux to zero
         # outside the input source spectrum's range.
-        if not isinstance(sourceSpectrum,SpectralFluxDensity):
-            sourceSpectrum = SpectralFluxDensity(
+        if not isinstance(sourceSpectrum,specsim.spectrum.SpectralFluxDensity):
+            sourceSpectrum = specsim.spectrum.SpectralFluxDensity(
                 sourceSpectrum[0],sourceSpectrum[1],extrapolatedValue=0.)
 
         # Resample the source spectrum to our simulation grid, if necessary.

--- a/specsim/sources.py
+++ b/specsim/sources.py
@@ -10,6 +10,7 @@ import numpy as np
 
 root2pi = np.sqrt(2*math.pi)
 
+
 def getOIIDoubletFlux(totalFlux,wave):
     """
     Returns a vector of [OII] doublet fluxes in erg/(s*cm^2*Ang) corresponding to the

--- a/specsim/spectrum.py
+++ b/specsim/spectrum.py
@@ -12,6 +12,7 @@ import scipy.integrate
 from astropy import constants as const
 from astropy import units
 
+
 class WavelengthFunction(object):
     """
     Represents an arbitrary function of wavelength.

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -38,9 +38,12 @@ def test_shape_to_focalplane():
 
     x, y = altaz_to_focalplane(angle[:, np.newaxis], angle, 0., 0.)
     assert x.shape == y.shape and x.shape == (3, 3)
+    '''
+    ## This test fails for numpy < 1.9 ... why??
     x, y = altaz_to_focalplane(angle, angle[:, np.newaxis],
         angle[:, np.newaxis, np.newaxis], 0.)
     assert x.shape == y.shape and x.shape == (3, 3, 3)
+    '''
 
 
 def test_focalplane_to_origin():

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -2,7 +2,7 @@
 
 from astropy.tests.helper import pytest
 from ..transform import altaz_to_focalplane, focalplane_to_altaz, \
-    observatories, sky_to_altaz
+    observatories, sky_to_altaz, adjust_time_to_hour_angle
 
 import numpy as np
 from astropy.time import Time
@@ -89,3 +89,18 @@ def test_altaz_null():
         wavelength=wlen, temperature=temperature, pressure=pressure)
     assert np.allclose(altaz_in.alt, altaz_out.alt)
     assert np.allclose(altaz_in.az, altaz_out.az)
+
+
+def test_adjust_null():
+    ra = 45 * u.deg
+    when = Time(56383, format='mjd', location=observatories['APO'])
+    ha = when.sidereal_time('apparent') - ra
+    adjusted = adjust_time_to_hour_angle(when, ra, ha)
+    assert adjusted == when
+
+
+def test_adjust_missing_longitude():
+    ra = 45 * u.deg
+    when = Time(56383, format='mjd', location=None)
+    with pytest.raises(ValueError):
+        adjusted = adjust_time_to_hour_angle(when, ra, 0.)

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -1,0 +1,46 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy.tests.helper import pytest
+from ..transform import altaz_to_focalplane
+
+import numpy as np
+
+
+def test_origin_to_focalplane():
+    ra, dec = 1.23, -3.21
+    x, y = altaz_to_focalplane(ra, dec, ra, dec)
+    assert np.allclose([x, y], [0, 0])
+
+
+def test_shape_to_focalplane():
+    x, y = altaz_to_focalplane(0., 0., 0., 0.)
+    assert x.shape == y.shape and x.shape == ()
+
+    angle = np.linspace(-0.1, +0.1, 3)
+    x, y = altaz_to_focalplane(angle, 0., 0., 0.)
+    assert x.shape == y.shape and x.shape == (3,)
+    x, y = altaz_to_focalplane(angle, angle, 0., 0.)
+    assert x.shape == y.shape and x.shape == (3,)
+    x, y = altaz_to_focalplane(angle, 0., angle, 0.)
+    assert x.shape == y.shape and x.shape == (3,)
+    x, y = altaz_to_focalplane(angle, 0., 0., angle)
+    assert x.shape == y.shape and x.shape == (3,)
+    x, y = altaz_to_focalplane(angle, angle, angle, 0.)
+    assert x.shape == y.shape and x.shape == (3,)
+    x, y = altaz_to_focalplane(angle, angle, 0., angle)
+    assert x.shape == y.shape and x.shape == (3,)
+    x, y = altaz_to_focalplane(angle, 0., angle, angle)
+    assert x.shape == y.shape and x.shape == (3,)
+    x, y = altaz_to_focalplane(0., angle, angle, angle)
+    assert x.shape == y.shape and x.shape == (3,)
+    x, y = altaz_to_focalplane(angle, angle, angle, angle)
+    assert x.shape == y.shape and x.shape == (3,)
+
+    x, y = altaz_to_focalplane(angle[:, np.newaxis], angle, 0., 0.)
+    assert x.shape == y.shape and x.shape == (3, 3)
+    x, y = altaz_to_focalplane(angle[:, np.newaxis],
+        angle[:, np.newaxis, np.newaxis], angle, 0.)
+    assert x.shape == y.shape and x.shape == (3, 3, 3)
+    x, y = altaz_to_focalplane(angle[:, np.newaxis],
+        angle[:, np.newaxis, np.newaxis], angle, angle[:, np.newaxis])
+    assert x.shape == y.shape and x.shape == (3, 3, 3)

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -11,47 +11,48 @@ import astropy.units as u
 
 
 def test_origin_to_focalplane():
-    alt, az = 0.5, 1.5
+    alt, az = 0.5 * u.rad, 1.5 * u.rad
     x, y = altaz_to_focalplane(alt, az, alt, az)
-    assert np.allclose([x, y], [0, 0])
+    assert np.allclose(x, 0 * u.rad) and np.allclose(y, 0 * u.rad)
 
 
 def test_shape_to_focalplane():
-    x, y = altaz_to_focalplane(0., 0., 0., 0.)
+    zero = 0. * u.rad
+    x, y = altaz_to_focalplane(zero, zero, zero, zero)
     assert x.shape == y.shape and x.shape == ()
 
-    angle = np.linspace(-0.1, +0.1, 3)
-    x, y = altaz_to_focalplane(angle, 0., 0., 0.)
+    angle = np.linspace(-0.1, +0.1, 3) * u.rad
+    x, y = altaz_to_focalplane(angle, zero, zero, zero)
     assert x.shape == y.shape and x.shape == (3,)
-    x, y = altaz_to_focalplane(angle, angle, 0., 0.)
+    x, y = altaz_to_focalplane(angle, angle, zero, zero)
     assert x.shape == y.shape and x.shape == (3,)
-    x, y = altaz_to_focalplane(angle, 0., angle, 0.)
+    x, y = altaz_to_focalplane(angle, zero, angle, zero)
     assert x.shape == y.shape and x.shape == (3,)
-    x, y = altaz_to_focalplane(angle, 0., 0., angle)
+    x, y = altaz_to_focalplane(angle, zero, zero, angle)
     assert x.shape == y.shape and x.shape == (3,)
-    x, y = altaz_to_focalplane(angle, angle, angle, 0.)
+    x, y = altaz_to_focalplane(angle, angle, angle, zero)
     assert x.shape == y.shape and x.shape == (3,)
-    x, y = altaz_to_focalplane(angle, angle, 0., angle)
+    x, y = altaz_to_focalplane(angle, angle, zero, angle)
     assert x.shape == y.shape and x.shape == (3,)
-    x, y = altaz_to_focalplane(angle, 0., angle, angle)
+    x, y = altaz_to_focalplane(angle, zero, angle, angle)
     assert x.shape == y.shape and x.shape == (3,)
-    x, y = altaz_to_focalplane(0., angle, angle, angle)
+    x, y = altaz_to_focalplane(zero, angle, angle, angle)
     assert x.shape == y.shape and x.shape == (3,)
     x, y = altaz_to_focalplane(angle, angle, angle, angle)
     assert x.shape == y.shape and x.shape == (3,)
-    x, y = altaz_to_focalplane(angle[:, np.newaxis], angle, 0., 0.)
+    x, y = altaz_to_focalplane(angle[:, np.newaxis], angle, zero, zero)
 
     assert x.shape == y.shape and x.shape == (3, 3)
     try:
         x, y = altaz_to_focalplane(angle, angle[:, np.newaxis],
-            angle[:, np.newaxis, np.newaxis], 0.)
+            angle[:, np.newaxis, np.newaxis], zero)
         assert x.shape == y.shape and x.shape == (3, 3, 3)
         x, y = altaz_to_focalplane(angle, angle[:, np.newaxis],
             angle[:, np.newaxis, np.newaxis],
             angle[:, np.newaxis, np.newaxis, np.newaxis])
         assert x.shape == y.shape and x.shape == (3, 3, 3, 3)
         x, y = altaz_to_focalplane(angle, angle[:, np.newaxis],
-            0., angle[:, np.newaxis, np.newaxis, np.newaxis])
+            zero, angle[:, np.newaxis, np.newaxis, np.newaxis])
         assert x.shape == y.shape and x.shape == (3, 1, 3, 3)
     except RuntimeError:
         # These tests fails for numpy < 1.9 because np.einsum does not
@@ -61,28 +62,28 @@ def test_shape_to_focalplane():
 
 
 def test_focalplane_to_origin():
-    alt0, az0 = 0.5, 1.5
-    alt, az = focalplane_to_altaz(0., 0., alt0, az0)
-    assert np.allclose([alt, az], [alt0, az0])
+    alt0, az0 = 0.5 * u.rad, 1.5 * u.rad
+    alt, az = focalplane_to_altaz(0. * u.rad, 0. * u.rad, alt0, az0)
+    assert np.allclose(alt, alt0) and np.allclose(az, az0)
 
 
 def test_focalplane_roundtrip():
-    alt0, az0 = 0.5, 1.5
-    x, y = -0.01, +0.02
+    alt0, az0 = 0.5 * u.rad, 1.5 * u.rad
+    x, y = -0.01 * u.rad, +0.02 * u.rad
     alt, az = focalplane_to_altaz(x, y, alt0, az0)
     x2, y2 = altaz_to_focalplane(alt, az, alt0, az0)
-    assert np.allclose([x, y], [x2, y2])
+    assert np.allclose(x, x2) and np.allclose(y, y2)
     alt2, az2 = focalplane_to_altaz(x2, y2, alt0, az0)
-    assert np.allclose([alt, az], [alt2, az2])
+    assert np.allclose(alt, alt2) and np.allclose(az, az2)
 
 
 def test_altaz_null():
-    alt, az = 0.5*u.rad, 1.5*u.rad
+    alt, az = 0.5 * u.rad, 1.5 * u.rad
     where = observatories['APO']
     when = Time(56383, format='mjd')
-    wlen = 5400*u.Angstrom
-    temperature = 5*u.deg_C
-    pressure = 800*u.kPa
+    wlen = 5400 * u.Angstrom
+    temperature = 5 * u.deg_C
+    pressure = 800 * u.kPa
     altaz_in = AltAz(alt=alt, az=az, location=where, obstime=when,
         obswl=wlen, temperature=temperature, pressure=pressure)
     altaz_out = sky_to_altaz(altaz_in, where=where, when=when,

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -9,6 +9,7 @@ from astropy.time import Time
 from astropy.coordinates import AltAz
 import astropy.units as u
 
+
 def test_origin_to_focalplane():
     alt, az = 0.5, 1.5
     x, y = altaz_to_focalplane(alt, az, alt, az)

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -16,6 +16,15 @@ def test_origin_to_focalplane():
     assert np.allclose(x, 0 * u.rad) and np.allclose(y, 0 * u.rad)
 
 
+def test_focalplane_units():
+    platescale = 200 * u.mm / u.deg
+    alt, az = 0.5 * u.rad, 1.5 * u.rad
+    x, y = altaz_to_focalplane(alt, az, alt, az, platescale=platescale)
+    assert x.unit == u.m and y.unit == u.m
+    alt, az = focalplane_to_altaz(x, y, alt, az, platescale=platescale)
+    assert alt.unit == u.rad and az.unit == u.rad
+
+
 def test_shape_to_focalplane():
     zero = 0. * u.rad
     x, y = altaz_to_focalplane(zero, zero, zero, zero)

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -38,15 +38,25 @@ def test_shape_to_focalplane():
     assert x.shape == y.shape and x.shape == (3,)
     x, y = altaz_to_focalplane(angle, angle, angle, angle)
     assert x.shape == y.shape and x.shape == (3,)
-
     x, y = altaz_to_focalplane(angle[:, np.newaxis], angle, 0., 0.)
+
     assert x.shape == y.shape and x.shape == (3, 3)
-    '''
-    ## This test fails for numpy < 1.9 ... why??
-    x, y = altaz_to_focalplane(angle, angle[:, np.newaxis],
-        angle[:, np.newaxis, np.newaxis], 0.)
-    assert x.shape == y.shape and x.shape == (3, 3, 3)
-    '''
+    try:
+        x, y = altaz_to_focalplane(angle, angle[:, np.newaxis],
+            angle[:, np.newaxis, np.newaxis], 0.)
+        assert x.shape == y.shape and x.shape == (3, 3, 3)
+        x, y = altaz_to_focalplane(angle, angle[:, np.newaxis],
+            angle[:, np.newaxis, np.newaxis],
+            angle[:, np.newaxis, np.newaxis, np.newaxis])
+        assert x.shape == y.shape and x.shape == (3, 3, 3, 3)
+        x, y = altaz_to_focalplane(angle, angle[:, np.newaxis],
+            0., angle[:, np.newaxis, np.newaxis, np.newaxis])
+        assert x.shape == y.shape and x.shape == (3, 1, 3, 3)
+    except RuntimeError:
+        # These tests fails for numpy < 1.9 because np.einsum does not
+        # broadcast correctly in this case. For details, See
+        # https://github.com/desihub/specsim/issues/10
+        pass
 
 
 def test_focalplane_to_origin():

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy.tests.helper import pytest
-from ..transform import altaz_to_focalplane, focalplane_to_altaz
+from ..transform import altaz_to_focalplane, focalplane_to_altaz, \
+    observatories, sky_to_altaz
 
 import numpy as np
-
+from astropy.time import Time
+from astropy.coordinates import AltAz
+import astropy.units as u
 
 def test_origin_to_focalplane():
     alt, az = 0.5, 1.5
@@ -60,3 +63,18 @@ def test_focalplane_roundtrip():
     assert np.allclose([x, y], [x2, y2])
     alt2, az2 = focalplane_to_altaz(x2, y2, alt0, az0)
     assert np.allclose([alt, az], [alt2, az2])
+
+
+def test_altaz_null():
+    alt, az = 0.5*u.rad, 1.5*u.rad
+    where = observatories['APO']
+    when = Time(56383, format='mjd')
+    wlen = 5400*u.Angstrom
+    temperature = 5*u.deg_C
+    pressure = 800*u.kPa
+    altaz_in = AltAz(alt=alt, az=az, location=where, obstime=when,
+        obswl=wlen, temperature=temperature, pressure=pressure)
+    altaz_out = sky_to_altaz(altaz_in, where=where, when=when,
+        wavelength=wlen, temperature=temperature, pressure=pressure)
+    assert np.allclose(altaz_in.alt, altaz_out.alt)
+    assert np.allclose(altaz_in.az, altaz_out.az)

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy.tests.helper import pytest
-from ..transform import altaz_to_focalplane
+from ..transform import altaz_to_focalplane, focalplane_to_altaz
 
 import numpy as np
 
 
 def test_origin_to_focalplane():
-    ra, dec = 1.23, -3.21
-    x, y = altaz_to_focalplane(ra, dec, ra, dec)
+    alt, az = 0.5, 1.5
+    x, y = altaz_to_focalplane(alt, az, alt, az)
     assert np.allclose([x, y], [0, 0])
 
 
@@ -38,9 +38,22 @@ def test_shape_to_focalplane():
 
     x, y = altaz_to_focalplane(angle[:, np.newaxis], angle, 0., 0.)
     assert x.shape == y.shape and x.shape == (3, 3)
-    x, y = altaz_to_focalplane(angle[:, np.newaxis],
-        angle[:, np.newaxis, np.newaxis], angle, 0.)
+    x, y = altaz_to_focalplane(angle, angle[:, np.newaxis],
+        angle[:, np.newaxis, np.newaxis], 0.)
     assert x.shape == y.shape and x.shape == (3, 3, 3)
-    x, y = altaz_to_focalplane(angle[:, np.newaxis],
-        angle[:, np.newaxis, np.newaxis], angle, angle[:, np.newaxis])
-    assert x.shape == y.shape and x.shape == (3, 3, 3)
+
+
+def test_focalplane_to_origin():
+    alt0, az0 = 0.5, 1.5
+    alt, az = focalplane_to_altaz(0., 0., alt0, az0)
+    assert np.allclose([alt, az], [alt0, az0])
+
+
+def test_focalplane_roundtrip():
+    alt0, az0 = 0.5, 1.5
+    x, y = -0.01, +0.02
+    alt, az = focalplane_to_altaz(x, y, alt0, az0)
+    x2, y2 = altaz_to_focalplane(alt, az, alt0, az0)
+    assert np.allclose([x, y], [x2, y2])
+    alt2, az2 = focalplane_to_altaz(x2, y2, alt0, az0)
+    assert np.allclose([alt, az], [alt2, az2])

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -8,8 +8,6 @@ observatories : dict
     Dictionary of predefined observing locations represented as
     :class:`astropy.coordinates.EarthLocation` objects.
 """
-from __future__ import print_function, division
-
 import numpy as np
 
 import astropy.time
@@ -39,10 +37,10 @@ def altaz_to_focalplane(alt, az, alt0, az0, platescale=1):
     >>> alt0, az0 = 45 * u.deg, 0 * u.deg
     >>> x, y = altaz_to_focalplane(alt0 + 1 * u.deg, az0, alt0, az0, scale)
     >>> print(np.round(x, 4), np.round(y, 4))
-    0.0 m 0.2 m
+    (<Quantity 0.0 m>, <Quantity 0.2 m>)
     >>> x, y = altaz_to_focalplane(alt0, az0 + 1 * u.deg, alt0, az0, scale)
     >>> print(np.round(x, 4), np.round(y, 4))
-    0.1414 m 0.0009 m
+    (<Quantity 0.1414 m>, <Quantity 0.0009 m>)
 
     This function implements a purely mathematical coordinate transform and does
     not invoke any atmospheric refraction physics.  Use :func:`sky_to_altaz`
@@ -134,7 +132,7 @@ def focalplane_to_altaz(x, y, alt0, az0, platescale=1):
     >>> alt, az = focalplane_to_altaz(x, y, alt0, az0, scale)
     >>> x, y = altaz_to_focalplane(alt, az, alt0, az0, scale)
     >>> print(np.round(x, 6), np.round(y, 6))
-    0.004 m -0.002 m
+    (<Quantity 0.004 m>, <Quantity -0.002 m>)
 
     Consult that function's documentation for details.
 
@@ -213,7 +211,7 @@ def sky_to_altaz(sky_coords, where, when, wavelength, temperature=15*u.deg_C,
     >>> sky = astropy.coordinates.ICRS(ra=45 * u.deg, dec = -30 * u.deg)
     >>> altaz = sky_to_altaz(sky, where, when, 5400 * u.Angstrom)
     >>> print(np.round(altaz.alt, 4), np.round(altaz.az, 4))
-    20d44m47.76s 210d06m12.96s
+    (<Latitude 20.7466 deg>, <Longitude 210.1036 deg>)
 
     The output shape is determined by the usual `numpy broadcasting rules
     <http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`__ applied

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -1,0 +1,99 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Implement transformations between sky and focal plane coordinate systems.
+"""
+from __future__ import print_function, division
+
+import numpy as np
+
+import astropy.time
+import astropy.coordinates
+import astropy.constants
+from astropy import units as u
+
+
+def altaz_to_focalplane(alt, az, alt0, az0):
+    """
+    Convert local (alt,az) coordinates to focal plane (x,y) coordinates.
+
+    A plate coordinate system is defined by its boresight altitude and azimuth,
+    corresponding to (x,y) = (0,0), and the conventions that +x increases
+    eastwards along the azimuth axis and +y increases towards the zenith along
+    the altitude axis.
+
+    This function implements a purely mathematical coordinate transform and does
+    not invoke any atmospheric refraction physics.  Use :func:`sky_to_altaz`
+    to convert global sky coordinates (ra,dec) into local (alt,az) coordinates,
+    which does involve refraction.
+
+    The input values can either be constants or numpy arrays. If any input is
+    not a numpy array, it will be automatically converted to a
+    :type:`numpy.float`. The output shape is determined by the usual
+    `numpy broadcasting rules
+    <http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`__
+    applied to all of the inputs.
+
+    All input values are assumed to be in radians and all output values are
+    calculated in radians.
+
+    Args:
+        alt(float or numpy.ndarray): Target altitude(s) in radians above the
+            horizon.
+        az(float numpy.ndarray): Target azimuthal angle(s) in radians east of
+            north.
+        alt0(float or numpy.ndarray): Boresight altitude(s) in radians above
+            the horizon.
+        az0(numpy.ndarray): Boresight azimuthal angle(s) in radians east of
+            north.
+
+    Returns:
+        tuple: Pair x,y of numpy arrays of focal-plane coordinates in radians,
+            with +x along the azimuth direction (increasing eastwards) and +y
+            along the altitude direction (increasing towards zenith). The
+            output arrays have the same shapes, given by
+            :func:`np.broadcast(alt, az, alt0, az0) <numpy.broadcast>`.
+    """
+    if not isinstance(alt, np.ndarray):
+        alt = np.float(alt)
+    if not isinstance(az, np.ndarray):
+        az = np.float(az)
+    if not isinstance(alt0, np.ndarray):
+        alt0 = np.float(alt0)
+    if not isinstance(az0, np.ndarray):
+        az0 = np.float(az0)
+
+    # Check that the input shapes are compatible for broadcasting to the output,
+    # otherwise this will raise a ValueError.
+    output_shape = np.broadcast(alt, az, alt0, az0).shape
+
+    # Convert (alt,az) to unit vectors.
+    cos_alt = np.cos(alt)
+    elem_shape = np.broadcast(alt, az).shape
+    u = np.empty(shape=[3,] + list(elem_shape))
+    u[0] = np.sin(az) * cos_alt
+    u[1] = np.cos(az) * cos_alt
+    u[2] = np.sin(alt)
+    ##u = (np.sin(az) * cos_alt, np.cos(az) * cos_alt, np.sin(alt))
+
+    # Build combined rotation matrices R[-alt0,x].R[+az0,z].
+    cos_alt0 = np.cos(alt0)
+    sin_alt0 = np.sin(alt0)
+    cos_az0 = np.cos(az0)
+    sin_az0 = np.sin(az0)
+    elem_shape = np.broadcast(alt0, az0).shape
+    R = np.empty(shape=[3,3] + list(elem_shape))
+    R[0, 0] = cos_az0
+    R[0, 1] = -sin_az0
+    R[0, 2] = 0.
+    R[1, 0] = cos_alt0 * sin_az0
+    R[1, 1] = cos_alt0 * cos_az0
+    R[1, 2] = sin_alt0
+    R[2, 0] = -sin_alt0 * sin_az0
+    R[2, 1] = -cos_az0 * sin_alt0
+    R[2, 2] = cos_alt0
+
+    # Calculate v = R.u
+    v = np.einsum('ij...,j...->i...', R, u)
+
+    # Convert unit vectors to (x,y).
+    return v[0], v[2]

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -37,10 +37,12 @@ def altaz_to_focalplane(alt, az, alt0, az0, platescale=1):
 
     >>> scale = 200 * u.mm / u.deg
     >>> alt0, az0 = 45 * u.deg, 0 * u.deg
-    >>> altaz_to_focalplane(alt0 + 1 * u.deg, az0, alt0, az0, scale)
-    (<Quantity 0.0 m>, <Quantity 0.19998984624065838 m>)
-    >>> altaz_to_focalplane(alt0, az0 + 1 * u.deg, alt0, az0, scale)
-    (<Quantity 0.1414141764452249 m>, <Quantity 0.0008726424738180304 m>)
+    >>> x, y = altaz_to_focalplane(alt0 + 1 * u.deg, az0, alt0, az0, scale)
+    >>> print(np.round(x, 4), np.round(y, 4))
+    0.0 m 0.2 m
+    >>> x, y = altaz_to_focalplane(alt0, az0 + 1 * u.deg, alt0, az0, scale)
+    >>> print(np.round(x, 4), np.round(y, 4))
+    0.1414 m 0.0009 m
 
     This function implements a purely mathematical coordinate transform and does
     not invoke any atmospheric refraction physics.  Use :func:`sky_to_altaz`
@@ -130,8 +132,9 @@ def focalplane_to_altaz(x, y, alt0, az0, platescale=1):
     >>> alt0, az0 = 45 * u.deg, 0 * u.deg
     >>> x, y = 4 * u.mm, -2 * u.mm
     >>> alt, az = focalplane_to_altaz(x, y, alt0, az0, scale)
-    >>> altaz_to_focalplane(alt, az, alt0, az0, scale)
-    (<Quantity 0.004000000000000002 m>, <Quantity -0.002000000000000512 m>)
+    >>> x, y = altaz_to_focalplane(alt, az, alt0, az0, scale)
+    >>> print(np.round(x, 6), np.round(y, 6))
+    0.004 m -0.002 m
 
     Consult that function's documentation for details.
 
@@ -209,8 +212,8 @@ def sky_to_altaz(sky_coords, where, when, wavelength, temperature=15*u.deg_C,
     >>> when = astropy.time.Time(56383, format='mjd')
     >>> sky = astropy.coordinates.ICRS(ra=45 * u.deg, dec = -30 * u.deg)
     >>> altaz = sky_to_altaz(sky, where, when, 5400 * u.Angstrom)
-    >>> altaz.alt, altaz.az
-    (<Latitude 20.746642144141592 deg>, <Longitude 210.10358458923005 deg>)
+    >>> print(np.round(altaz.alt, 4), np.round(altaz.az, 4))
+    20d44m47.76s 210d06m12.96s
 
     The output shape is determined by the usual `numpy broadcasting rules
     <http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`__ applied

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -120,21 +120,26 @@ def focalplane_to_altaz(x, y, alt0, az0):
     This is the inverse of :func:`altaz_to_focalplane`. Consult that function's
     documentation for details.
 
-    Args:
-        x (float or numpy.ndarray): Target x position(s) in radians with +x
-            increasing eastwards along the azimuth direction.
-        y (float numpy.ndarray): Target y position(s) in radians with +y
-            increasing towards the zenith along the altitude direction.
-        alt0 (float or numpy.ndarray): Boresight altitude(s) in radians above
-            the horizon.
-        az0 (numpy.ndarray): Boresight azimuthal angle(s) in radians east of
-            north.
+    Parameters
+    ----------
+    x: float or numpy.ndarray
+        Target x position(s) in radians with +x increasing eastwards along the
+        azimuth direction.
+    y: float numpy.ndarray
+        Target y position(s) in radians with +y increasing towards the zenith
+        along the altitude direction.
+    alt0: float or numpy.ndarray
+        Boresight altitude(s) in radians above the horizon.
+    az0: float or numpy.ndarray
+        Boresight azimuthal angle(s) in radians east of north.
 
-    Returns:
-        tuple: Pair alt,az of numpy arrays of local sky coordinates in radians,
-            with alt measured above the horizon and az increasing eastwards of
-            north. The output arrays have the same shapes, given by
-            :func:`np.broadcast(x, y, alt0, az0) <numpy.broadcast>`.
+    Returns
+    -------
+    result: tuple
+        Pair alt,az of numpy arrays of local sky coordinates in radians,
+        with alt measured above the horizon and az increasing eastwards of
+        north. The output arrays have the same shapes, given by
+        :func:`np.broadcast(x, y, alt0, az0) <numpy.broadcast>`.
     """
     if not isinstance(x, np.ndarray):
         x = np.float(x)
@@ -190,31 +195,40 @@ def sky_to_altaz(sky_coords, where, when, wavelength, temperature=15*u.deg_C,
     <http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`__ applied
     to all of the inputs.
 
-    Args:
-        sky_coords (object): An object representing one or more sky coordinates that are
-            transformable to an AltAz frame by invoking ``sky_coords.transform_to()``.
-            This argument will usually be an
-            instances of :class:`astropy.coordinates.SkyCoord`, but instances
-            of :class:`astropy.coordinates.AltAz` can also be used to isolate
-            the effects of changing the parameters of the atmospheric
-            refraction model.
-        where (astropy.coordinates.EarthLocation): The location where the
-            observations take place.
-        when (astropy.time.Time): The time(s) of the observations.
-        wavelength (astropy.units.Quantity): The wavelength(s) of the observations.
-        temperature (astropy.units.Quantity): The temperature(s) of the observations.
-        pressure (astropy.units.Quantity): The atmospheric pressure(s) of the
-            observations. These should be pressures at the telescope, rather
-            than adjusted to equivalent sea-level pressures. When ``None`` is
-            specified, the pressure(s) will be estimated at the telescope
-            elevation using a standard atmosphere model at the specified temperature(s).
-        relative_humidity (float or numpy.ndarray): Relative humidity (or
-            humidities) of the observations. Value(s) should be in the range
-            0-1 and are dimensionless.
+    Parameters
+    ----------
+    sky_coords: object
+        An object representing one or more sky coordinates that are
+        transformable to an AltAz frame by invoking
+        ``sky_coords.transform_to()``. This argument will usually be an
+        instances of :class:`astropy.coordinates.SkyCoord`, but instances
+        of :class:`astropy.coordinates.AltAz` can also be used to isolate
+        the effects of changing the parameters of the atmospheric
+        refraction model.
+    where: astropy.coordinates.EarthLocation
+        The location where the observations take place.
+    when: astropy.time.Time
+        The time(s) of the observations.
+    wavelength: astropy.units.Quantity
+        The wavelength(s) of the observations.
+    temperature: astropy.units.Quantity
+        The temperature(s) of the observations.
+    pressure: astropy.units.Quantity
+        The atmospheric pressure(s) of the
+        observations. These should be pressures at the telescope, rather
+        than adjusted to equivalent sea-level pressures. When ``None`` is
+        specified, the pressure(s) will be estimated at the telescope elevation
+        using a standard atmosphere model at the specified temperature(s).
+    relative_humidity: float or numpy.ndarray
+        Relative humidity (or humidities) of the observations. Value(s) should
+        be in the range 0-1 and are dimensionless.
 
-    Returns:
-        astropy.coordinates.AltAz: An array of ALT-AZ coordinates with a shape
-            given by :func:`np.broadcast(sky_coords, when, wavelength, temperature, pressure) <numpy.broadcast>`.
+    Returns
+    -------
+    result: astropy.coordinates.AltAz
+        An array of ALT-AZ coordinates with a shape given by
+        :func:`np.broadcast(sky_coords, when, wavelength, temperature, pressure)
+        <numpy.broadcast>`.
     """
     if not isinstance(relative_humidity, np.ndarray):
         relative_humidity = np.float(relative_humidity)

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -36,11 +36,11 @@ def altaz_to_focalplane(alt, az, alt0, az0, platescale=1):
     >>> scale = 200 * u.mm / u.deg
     >>> alt0, az0 = 45 * u.deg, 0 * u.deg
     >>> x, y = altaz_to_focalplane(alt0 + 1 * u.deg, az0, alt0, az0, scale)
-    >>> round(x.to(u.mm).value, 2), round(y.to(u.mm).value, 2)
-    (0.0, 199.99)
+    >>> print('X = %.2f mm, Y = %.2f mm' % (x.to(u.mm).value, y.to(u.mm).value))
+    X = 0.00 mm, Y = 199.99 mm
     >>> x, y = altaz_to_focalplane(alt0, az0 + 1 * u.deg, alt0, az0, scale)
-    >>> round(x.to(u.mm).value, 2), round(y.to(u.mm).value, 2)
-    (141.41, 0.87)
+    >>> print('X = %.2f mm, Y = %.2f mm' % (x.to(u.mm).value, y.to(u.mm).value))
+    X = 141.41 mm, Y = 0.87 mm
 
     This function implements a purely mathematical coordinate transform and does
     not invoke any atmospheric refraction physics.  Use :func:`sky_to_altaz`
@@ -131,8 +131,8 @@ def focalplane_to_altaz(x, y, alt0, az0, platescale=1):
     >>> x, y = 4 * u.mm, -2 * u.mm
     >>> alt, az = focalplane_to_altaz(x, y, alt0, az0, scale)
     >>> x, y = altaz_to_focalplane(alt, az, alt0, az0, scale)
-    >>> round(x.to(u.mm).value, 2), round(y.to(u.mm).value, 2)
-    (4.0, -2.0)
+    >>> print('X = %.2f mm, Y = %.2f mm' % (x.to(u.mm).value, y.to(u.mm).value))
+    X = 4.00 mm, Y = -2.00 mm
 
     Consult that function's documentation for details.
 
@@ -210,10 +210,11 @@ def sky_to_altaz(sky_coords, where, when, wavelength, temperature=15*u.deg_C,
     >>> when = astropy.time.Time('2001-01-01T00:00:00')
     >>> polaris = astropy.coordinates.ICRS(ra=37.95 * u.deg, dec=89.25 * u.deg)
     >>> altaz = sky_to_altaz(polaris, where, when, 5400 * u.Angstrom)
-    >>> round(altaz.alt.to(u.deg).value, 3), round(altaz.az.to(u.deg).value, 3)
-    (32.465, 0.667)
-    >>> round(where.latitude.to(u.deg).value, 3)
-    31.963
+    >>> print('alt = %.3f deg, az = %.3f deg' %
+    ... (altaz.alt.to(u.deg).value, altaz.az.to(u.deg).value))
+    alt = 32.465 deg, az = 0.667 deg
+    >>> print('lat = %.3f deg' % where.latitude.to(u.deg).value)
+    lat = 31.963 deg
 
     The output shape is determined by the usual `numpy broadcasting rules
     <http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`__ applied
@@ -304,8 +305,8 @@ def adjust_time_to_hour_angle(nominal_time, target_ra, hour_angle,
     >>> night = astropy.time.Time(55100, format='mjd', location=where)
     >>> polaris = astropy.coordinates.ICRS(ra=37.95 * u.deg, dec=89.25 * u.deg)
     >>> when = adjust_time_to_hour_angle(night, polaris.ra, 0 * u.deg)
-    >>> round(when.mjd, 3)
-    55099.403
+    >>> print('MJD %.3f' % when.mjd)
+    MJD 55099.403
 
     Parameters
     ----------

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -28,7 +28,7 @@ def altaz_to_focalplane(alt, az, alt0, az0):
 
     The input values can either be constants or numpy arrays. If any input is
     not a numpy array, it will be automatically converted to a
-    :type:`numpy.float`. The output shape is determined by the usual
+    :class:`numpy.float`. The output shape is determined by the usual
     `numpy broadcasting rules
     <http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`__
     applied to all of the inputs.

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -85,7 +85,6 @@ def altaz_to_focalplane(alt, az, alt0, az0):
     u[0] = np.sin(az) * cos_alt
     u[1] = np.cos(az) * cos_alt
     u[2] = np.sin(alt)
-    ##u = (np.sin(az) * cos_alt, np.cos(az) * cos_alt, np.sin(alt))
 
     # Build combined rotation matrices R[-alt0,x].R[+az0,z].
     cos_alt0 = np.cos(alt0)
@@ -106,6 +105,10 @@ def altaz_to_focalplane(alt, az, alt0, az0):
 
     # Calculate v = R.u
     v = np.einsum('ij...,j...->i...', R, u)
+    if v[0].shape != output_shape:
+        raise RuntimeError(
+            'np.einsum does not broadcast correctly in numpy {}.'
+            .format(np.version.version))
 
     # Convert unit vectors to (x,y).
     return v[0], v[2]

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -191,9 +191,9 @@ def sky_to_altaz(sky_coords, where, when, wavelength, temperature=15*u.deg_C,
     to all of the inputs.
 
     Args:
-        sky_coords: An object representing one or more sky coordinates that are
-            transformable to an AltAz frame by invoking
-            ``sky_coords.transform_to()``.  This argument will usually be an
+        sky_coords (object): An object representing one or more sky coordinates that are
+            transformable to an AltAz frame by invoking ``sky_coords.transform_to()``.
+            This argument will usually be an
             instances of :class:`astropy.coordinates.SkyCoord`, but instances
             of :class:`astropy.coordinates.AltAz` can also be used to isolate
             the effects of changing the parameters of the atmospheric
@@ -201,26 +201,20 @@ def sky_to_altaz(sky_coords, where, when, wavelength, temperature=15*u.deg_C,
         where (astropy.coordinates.EarthLocation): The location where the
             observations take place.
         when (astropy.time.Time): The time(s) of the observations.
-        wavelength (astropy.units.Quantity): The wavelength(s) of the
-            observations.
-
-        temperature (astropy.units.Quantity): The temperature(s) of the
-            observations.
+        wavelength (astropy.units.Quantity): The wavelength(s) of the observations.
+        temperature (astropy.units.Quantity): The temperature(s) of the observations.
         pressure (astropy.units.Quantity): The atmospheric pressure(s) of the
             observations. These should be pressures at the telescope, rather
             than adjusted to equivalent sea-level pressures. When ``None`` is
             specified, the pressure(s) will be estimated at the telescope
-            elevation using a standard atmosphere model at the specified
-            temperature(s).
-        relative_humidity( float or numpy.ndarray): Relative humidity (or
+            elevation using a standard atmosphere model at the specified temperature(s).
+        relative_humidity (float or numpy.ndarray): Relative humidity (or
             humidities) of the observations. Value(s) should be in the range
             0-1 and are dimensionless.
 
     Returns:
         astropy.coordinates.AltAz: An array of ALT-AZ coordinates with a shape
-            given by
-            :func:`np.broadcast(sky_coords, when, wavelength, temperature, pressure)
-            <numpy.broadcast>`.
+            given by :func:`np.broadcast(sky_coords, when, wavelength, temperature, pressure) <numpy.broadcast>`.
     """
     if not isinstance(relative_humidity, np.ndarray):
         relative_humidity = np.float(relative_humidity)

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -48,22 +48,25 @@ def altaz_to_focalplane(alt, az, alt0, az0):
     All input values are assumed to be in radians and all output values are
     calculated in radians.
 
-    Args:
-        alt (float or numpy.ndarray): Target altitude(s) in radians above the
-            horizon.
-        az (float numpy.ndarray): Target azimuthal angle(s) in radians east of
-            north.
-        alt0 (float or numpy.ndarray): Boresight altitude(s) in radians above
-            the horizon.
-        az0 (numpy.ndarray): Boresight azimuthal angle(s) in radians east of
-            north.
+    Parameters
+    ----------
+    alt : :class:`float` or :class:`numpy.ndarray`
+        Target altitude(s) in radians above the horizon.
+    az : :class:`float` or :class:`numpy.ndarray`
+        Target azimuthal angle(s) in radians east of north.
+    alt0 : :class:`float` or :class:`numpy.ndarray`
+        Boresight altitude(s) in radians above the horizon.
+    az0 : :class:`float` or :class:`numpy.ndarray`
+        Boresight azimuthal angle(s) in radians east of north.
 
-    Returns:
-        tuple: Pair x,y of numpy arrays of focal-plane coordinates in radians,
-            with +x along the azimuth direction (increasing eastwards) and +y
-            along the altitude direction (increasing towards zenith). The
-            output arrays have the same shapes, given by
-            :func:`np.broadcast(alt, az, alt0, az0) <numpy.broadcast>`.
+    Returns
+    -------
+    :class:`tuple`
+        Pair x,y of numpy arrays of focal-plane coordinates in radians,
+        with +x along the azimuth direction (increasing eastwards) and +y
+        along the altitude direction (increasing towards zenith). The
+        output arrays have the same shapes, given by
+        :func:`np.broadcast(alt, az, alt0, az0) <numpy.broadcast>`.
     """
     if not isinstance(alt, np.ndarray):
         alt = np.float(alt)
@@ -122,20 +125,20 @@ def focalplane_to_altaz(x, y, alt0, az0):
 
     Parameters
     ----------
-    x: float or numpy.ndarray
+    x : :class:`float` or :class:`numpy.ndarray`
         Target x position(s) in radians with +x increasing eastwards along the
         azimuth direction.
-    y: float numpy.ndarray
+    y : :class:`float` or :class:`numpy.ndarray`
         Target y position(s) in radians with +y increasing towards the zenith
         along the altitude direction.
-    alt0: float or numpy.ndarray
+    alt0 : :class:`float` or :class:`numpy.ndarray`
         Boresight altitude(s) in radians above the horizon.
-    az0: float or numpy.ndarray
+    az0 : :class:`float` or :class:`numpy.ndarray`
         Boresight azimuthal angle(s) in radians east of north.
 
     Returns
     -------
-    result: tuple
+    :class:`tuple`
         Pair alt,az of numpy arrays of local sky coordinates in radians,
         with alt measured above the horizon and az increasing eastwards of
         north. The output arrays have the same shapes, given by
@@ -197,7 +200,7 @@ def sky_to_altaz(sky_coords, where, when, wavelength, temperature=15*u.deg_C,
 
     Parameters
     ----------
-    sky_coords: object
+    sky_coords : :class:`object`
         An object representing one or more sky coordinates that are
         transformable to an AltAz frame by invoking
         ``sky_coords.transform_to()``. This argument will usually be an
@@ -205,27 +208,27 @@ def sky_to_altaz(sky_coords, where, when, wavelength, temperature=15*u.deg_C,
         of :class:`astropy.coordinates.AltAz` can also be used to isolate
         the effects of changing the parameters of the atmospheric
         refraction model.
-    where: astropy.coordinates.EarthLocation
+    where : :class:`astropy.coordinates.EarthLocation`
         The location where the observations take place.
-    when: astropy.time.Time
+    when : :class:`astropy.time.Time`
         The time(s) of the observations.
-    wavelength: astropy.units.Quantity
-        The wavelength(s) of the observations.
-    temperature: astropy.units.Quantity
-        The temperature(s) of the observations.
-    pressure: astropy.units.Quantity
-        The atmospheric pressure(s) of the
-        observations. These should be pressures at the telescope, rather
+    wavelength : :class:`astropy.units.Quantity`
+        The wavelength(s) of the observations with units of length.
+    temperature : :class:`astropy.units.Quantity`
+        The temperature(s) of the observations with temperature units.
+    pressure : :class:`astropy.units.Quantity`
+        The atmospheric pressure(s) of the observations with appropriate units.
+        These should be pressures at the telescope, rather
         than adjusted to equivalent sea-level pressures. When ``None`` is
         specified, the pressure(s) will be estimated at the telescope elevation
         using a standard atmosphere model at the specified temperature(s).
-    relative_humidity: float or numpy.ndarray
+    relative_humidity : :class:`float` or :class:`numpy.ndarray`
         Relative humidity (or humidities) of the observations. Value(s) should
         be in the range 0-1 and are dimensionless.
 
     Returns
     -------
-    result: astropy.coordinates.AltAz
+    :class:`astropy.coordinates.AltAz`
         An array of ALT-AZ coordinates with a shape given by
         :func:`np.broadcast(sky_coords, when, wavelength, temperature, pressure)
         <numpy.broadcast>`.


### PR DESCRIPTION
Implement focal plane transforms as a prelude to calculating the fiber acceptance fractions needed for #5  and #3.  These will also be used in `desihub/desietc` and for the eBOSS DR13 Margala corrections.

Fixes #10.