### PR TITLE
Implement alt,az to ra,dec transform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ before_install:
     - export PYTHONIOENCODING=UTF8
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
-    - ./miniconda.sh -b
+    - ./miniconda.sh -b -p $HOME/miniconda
     - export PATH=/home/travis/miniconda/bin:$PATH
     - conda update --yes conda
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ recursive-include scripts *
 prune build
 prune docs/_build
 prune docs/api
+prune docs/nb
 
 recursive-include astropy_helpers *
 exclude astropy_helpers/.git

--- a/docs/nb/.gitignore
+++ b/docs/nb/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints

--- a/docs/nb/TransformExamples.ipynb
+++ b/docs/nb/TransformExamples.ipynb
@@ -1,0 +1,231 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Transform Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Examples to demonstrate the `specsim.transform` module documented [here](http://specsim.readthedocs.org/en/latest/api.html#module-specsim.transform)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pylab inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/david/anaconda/lib/python2.7/site-packages/IPython/kernel/__init__.py:13: ShimWarning: The `IPython.kernel` package has been deprecated. You should import from ipykernel or jupyter_client instead.\n",
+      "  \"You should import from ipykernel or jupyter_client instead.\", ShimWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import astropy.units as u\n",
+    "import astropy.time\n",
+    "import astropy.coordinates\n",
+    "import astropy.table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.2.dev260\n"
+     ]
+    }
+   ],
+   "source": [
+    "import specsim\n",
+    "print specsim.__version__\n",
+    "from specsim.transform import create_observing_model, sky_to_altaz, altaz_to_sky"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Atmospheric Refraction Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set default observing model parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "where = specsim.transform.observatories['KPNO']\n",
+    "when = astropy.time.Time(56383, format='mjd')\n",
+    "wlen = 5400 * u.Angstrom\n",
+    "temperature = 5 * u.deg_C\n",
+    "pressure = 800 * u.kPa\n",
+    "default_model = specsim.transform.create_observing_model(where=where, when=when,\n",
+    "    wavelength=wlen, temperature=temperature, pressure=pressure)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculate the round trip accuracy as a function of altitude:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "alt_in = np.linspace(10., 89., 80) * u.deg\n",
+    "az_in = 90 * u.deg\n",
+    "roundtrip_sky = altaz_to_sky(alt_in, az_in, default_model)\n",
+    "altaz_out = sky_to_altaz(roundtrip_sky, default_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAESCAYAAAAMifkAAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJztnXd4VGX2xz+HnoSS0EInAtIEBBVFEQiKCgqC2EBlRV39\nrWtb266uqwR117Ur7rqWlWYB266CvTHqKooFFEVAEaRKDQQInfP7450Jk5AyM7mTuZOcz/Pch3nf\ne+97v3Oj98w9533PEVXFMAzDMEqjWqIFGIZhGP7HjIVhGIZRJmYsDMMwjDIxY2EYhmGUiRkLwzAM\no0zMWBiGYRhlYsbCMAzDKBMzFoZhGEaZ1Ei0gJIQkeHAaUB94ClVfTfBkgzDMKos4vcV3CKSDtyn\nqr9NtBbDMIyqSoW6oURkooisFZH5RfoHi8hCEflRRP5U5LS/AP+oOJWGYRhGUSo6ZjEJGBzeISLV\nccZgMNAVGC0iXcRxN/Cmqs6rYJ2GYRhGGBUas1DVj0Ukq0j30cBPqroMQESmA8OBQcCJQH0R6aCq\nj1egVMMwDCMMPwS4WwIrwtorgWNU9SrgkcRIMgzDMMLxg7GIOcIuIv6OzhuGYfgUVZVojvfDOotV\nQOuwdmvc20VEqKrvt3HjxiVcg+k0nabTNIa2WPCDsfgSOFREskSkFnAuMCPSk3NycggEAvHS5gnL\nli1LtISIMJ3eYjq9JRl0+l1jIBAgJycnpnMreursNOBToKOIrBCRi1R1L3Al8DawAHheVX+IdMyc\nnByys7PjotcwDKMykZ2dHbOxqOjZUKNL6H8TeDOWMUPGws8GY+zYsYmWEBGm01tMp7ckg06/awwE\nAjF7Yny/grs0RESTWb9hGEYiEBE0CQPclR6/x1RCmE5v8ZNOEbGtim5e4Yeps4ZhVAD2Fl718NJY\nJL0baty4cb6PWRhGohERMxZVkKJ/91DMYvz48VG7oZLeWCSzfsOoKMxYVE1K+rsH+y1m4Tf85Lsu\nDdPpLcmiMxkYO3Yst956a4n777rrLi699FLPrpeTk8OYMWM8G68yYMbCMAzfkJ2dTcOGDdm9e3eh\n/vBgbSAQoHXr1oX233zzzTz55JOAWxhXrVo19u/fH7OO8vj6s7KySE1NpV69egXb1VdfHfN4fsGM\nRQWQLPEU0+ktyaLTLyxbtow5c+bQtGlTZsw4OIlDtG60RLndRITXXnuNrVu3FmwTJkwo9th9+/Yd\n1BetkSuPUYwGMxaGYfiCqVOnMmjQIMaMGcOUKVMO2i8i5OfnM2TIEFavXk29evWoX78+a9asKeQ2\n6t+/PwDp6enUr1+fzz777CC3UtG3j6VLlzJgwADq16/PySefzIYNGwpd+7PPPuO4444jIyODnj17\n8uGHH8b0HSdPnkzfvn257rrraNy4MTk5OVx00UVcfvnlnHrqqdStW5dAIMAPP/xAdnY2GRkZdOvW\njZkzZxaMMXbs2IOOrwh8ayxE5BAR+beIvFjaccmQG8rv+kKYTm9JFp1+YerUqZx77rmcc845vP32\n26xbt67QflUlNTWVt956ixYtWrB161by8vJo3rx5IbfRxx9/DMCWLVvIy8ujT58+ZbqVzjvvPHr3\n7s3GjRu59dZbmTJlSsE5q1atYujQodx2223k5uZy3333ceaZZx5kUIpqLYk5c+bQvn171q1bxy23\n3IKqMm3aNG699Va2bdtG7969GTZsGIMHD2b9+vU88sgjnH/++SxevLhgjPDj+/btW+p3CydpckNF\ng6ou1QjqbltuKMNIfv73v/+xatUqTj/9dA499FC6du3Kc889V+yxxT2Iw/vK2l+U5cuX8+WXX3LH\nHXdQs2ZN+vXrx7Bhwwr2P/PMM5x66qkMHuyKfA4aNIijjjqKN954o0R9I0aMICMjo2B76qmnCva3\naNGCK664gmrVqlGnTh1EhBEjRnDssccCMG/ePLZv385NN91EjRo1GDhwIEOHDmXatGkFY4QfX7t2\n7RK/W1HKkxsqGWpwl8qDD3qrMR4kizEznd6SLDpDiHizxcKUKVM4+eSTqVevHgBnn312sa6oeLB6\n9WoyMjJISUkp6Gvbtm2Bgfnll1948cUXCz38P/nkE3799ddixxMRXn31VXJzcwu2Sy65pGB/0eA8\nQKtWrQrpKXpM27ZtWb16dcH4xY0Rbyp6BfckXPW7qaEOOVCDexCutsUXIjIj0syzEyZArVpwxRXx\nkGsYVYdELcPYsWMHL7zwAvv376d58+YA7Nq1i82bN/Ptt9/So0cP4MAMpeJcSuF9xe2vW7cu+fn5\nBe3wB33z5s3Jzc0lPz+f1NRUwBmI6tWrA9CmTRvGjBnDE088Ud6vGpH+Fi1asGLFClS1oP+XX36h\nc+fOnlw/Vir0zUJVPwZyi3QX1OBW1T3AdGC4iDQUkceAnqW9bXzwAdx9N/z73/HTXV6SxXdtOr0l\nWXQmmldeeYUaNWrwww8/8M033/DNN9/www8/0K9fP6ZOdb8rw4v2ZGZmsnHjRvLy8grGCHczNWnS\nhGrVqrFkyZKCvp49e/LRRx+xYsUKtmzZwl133VWwr23bthx11FGMGzeOPXv28L///Y/XXnutYP8F\nF1zAzJkzeeedd9i3bx87d+4kEAiwatWqEr9TNDOxih7bp08fUlNTueeee9izZw+BQIDXXnuNUaNG\nRT22l/ghZlFcDe6WqrpJVX+nqoeq6t0lnXzIIfD++5CTA1OnlnSUYRh+ZerUqVx88cW0atWKpk2b\n0rRpUzIzM7nyyit57rnn2LdvX6F1Fp07d2b06NG0a9eOhg0bsmbNmkL7U1NTueWWW+jbty8ZGRnM\nmTOHQYMGce6559KjR4+CAHL4r/nnnnuOzz//nIYNG3L77bdz4YUXFuxr1aoVr776Kn/7299o2rQp\nbdq04f777y91yuqwYcMKrbM488wzgcLrRUIU7atZsyYzZ87kzTffpEmTJlx55ZU8/fTTdOzYscQx\nKoIKT/chIlnATFXtHmyfCQxW1UuD7QuAY1T1qgjG0gsvvJCsrCzWr4enn07n97/vyd//ng0c+GUX\n8h1b29pVtW3pPqomob97IBBg8uTJgFs0mBS5oYoxFn2AHFUdHGzfDOwv7W0ibKxCuaEWLoSTT4Yb\nb4SryjQ1hlF1MGNRNalsuaE8q8HduTN8/LELet95Z+ICdkVJFt+16fSWZNFpVB2SZp2FVEAN7rZt\nncF4/nn3huEXg2EYhpFoyrPOIulTlJdUz2LTJjj1VOjUCZ580k2vNYyqirmhqiZWzyJIWfUstm+H\n88+HvDx4+WXIyKhAcYbhI8xYVE0qW8wibqSlOSNx+OHQty8sW5YYHcniuzad3pIsOg0jEiq1sQCo\nXt2lBLn8cjjuOPj880QrMgzDSD7KdEOJSDpwLJAFKLAMmK2qW+ItriyircE9cyZcfDHccw9cdFH8\n9RmGXzA3VNWkQmIWItIPuBFnJOYCqwEBmgO9cEbjHlX9XwzfwRNiqcG9YAGMGAGnnAIPPAA1a8ZJ\nnGH4iMpqLJ599lmmTp3K22+/XSHXy8rK4qmnnuLEE0+skOuVl4qKWZwBXK+qPVT1QlW9WVVvCn7u\nAdwAjIxKuQ/o2hXmzIGlS2HQICiSMj8uJIvv2nR6S7Lo9BPZJZRVLYnzzz8/boaiuLrf0aTamDx5\nMtWrVy+U9qN+/folZqv1OyUaC1W9TlV/LGX/YlW9Lj6y4kt6OsyYAf37w5FHunUZhmEklrLKqiYj\nffv2LVReNS8vj2bNmh103N69eyPqK41oj4+WMgPcInKXiGSEtTNE5M64qqoAqlWDO+6Axx+Hs8+G\nu+6CeJWyTZa6BqbTW5JFp18oqaxqqIRqaEtNTaVaNffomjx5Mv369Ss4tlq1avzrX//i0EMPpX79\n+tx2220sWbKEY489lvT0dEaNGsWePXuKPTd0/pIlS3jiiSd47rnnuOeee6hXrx7Dhw8vOGbu3Lkc\nfvjhBePt2rWrxO9UmusvKyuLe+65hx49elCvXj2WLFlCtWrVmDhxIm3btmXQoEGoKnfeeSdZWVlk\nZmZy4YUXFmTbDZWGDT8+roRS/5a0AfOK6Ztb1nkVsTn55WfFCtW+fVVPOUV13TpPhjQMX+HV/yvx\npH379vrMM8/o4sWLtWbNmrp27dpijzv//PP1vPPOU1XVSZMm6fHHH1+wT0R0xIgRunXrVv3++++1\nVq1aOnDgQF26dKlu2bJFu3btqlOmTCn23ND5S5YsUVXVsWPH6q233lpof9u2bfWYY47RNWvW6KZN\nm7RLly762GOPFauzuPGLjtWrVy9duXKl7ty5U5cuXarB5Kian5+vO3bs0Keeeko7dOigS5cu1W3b\ntunIkSN1zJgxqqoHHb9z586DrlHS3z3YH9XzNpKps9VEpE6oISIpgG/WQ3tRg7tVKwgE4IgjoFcv\neOcdT6QVkCy+a9PpLcmi0w9EWlb17rvvZtGiRUycOLHEsf74xz9St25dunbtSvfu3RkyZAhZWVnU\nr1+fIUOGMHfu3Ih1aZE3AxHh6quvplmzZmRkZDBs2DDmzZtX4vmfffZZoQp7hx566EFjtWzZslBp\n1JycHFJSUqhTpw7PPvss119/PVlZWaSlpXHXXXcxffr0QunRQ8dHUl61PLmhIqmU9yzwvohMxM2G\nuoiwSnfxQkTSgEeBXUBAVYstyBvrFy9KjRrwt7/BCSe4abUjR8Lf/w5hlRYNo1Ij472pkaDjop91\nVVJZ1T/84Q8Fx7z55ptMmDCBOXPmlPpgzMzMLPickpJSqF2nTh3Wrl0btb5wwmMOKSkpBeVOi6NP\nnz58XEpQtLjyqOF9a9asoW3btgXtNm3asHfv3kLfIZoSq6FlBuPHj4/4nBBlGgtVvVtEvgVCc8Vu\nV9WKmKc2EnhBVV8XkelA8dXbPWbQIPjmG7eI76ij4NlnoWfP8o2ZLL5r0+ktyaIzRCwPeS+IpKzq\nokWLGDt2LP/9739p2bJlzNcKn8mUlpZWYqnVosdGMl559RTX16JFC5aFpZ5Yvnw5NWrUIDMzk+XL\nl3uiIVIiXcH9A/C2qt4AfCwi9WK5mIhMFJG1IjK/SP9gEVkoIj+GlVANr6C3L5brxUrDhjB9Otx8\nM5x0kguEB2NihmF4TFllVfPy8hg+fDh//etfOe6446IeP9yVFP758MMP5/vvv+ebb75h586dB3kp\nMjMz+fnnnyMeOx6MHj2aBx98kGXLlrFt2zb+/Oc/M2rUqIIAf0USyWyoy4AXgceCXa2AV2K83iRg\ncJHxqwP/CPZ3BUaLSBdcedXQ+1WF3xkRuOAC+Ppr+PRTOPpoKMU1WSrJ4rs2nd6SLDoTTVllVb/4\n4gsWL17MtddeW2i9Ahy87qGsX+rhx3fs2JHbbruNQYMG0alTJ/r161fo2EsuuYQFCxaQkZHByJHF\nLykrbd2FiDB79uxCM7nq1avHV199VeK9KDrWxRdfzJgxY+jfvz/t2rUjNTWVRx55pNTvGzfKioAD\n3wC1CZsBBcyPNpIedm5W+Pm4VCJvhbVvCm6pwERc3GJ0CWOVONPAS/bvV500SbVJE9Vbb1UtZtJB\nqcyaNSsesjzHdHqLn3RW1P8rhr8o6e9ODLOhIglw71LVXSELJiI1cDmivCLc3QTujeIYVc0HLi7r\n5LFjx5KVlQVAeno6PXv2jEsN47FjoW7dAA88AC+9lM1jj8H+/d6N74d2qM8vepK9Herzkx6jahIo\nUoM7FiJJJHgvsBn4Da6i3e+BBap6S0wXPLgG95nAYFW9NNi+AGcsyqyiHUtuqPKiCv/9L1x9NQwe\n7JISNmxYoRIMI2oqa24oo3Qqup7FTcB6YD7wf8AbwF+iuUgZrOJAbILg55WRnuzFOotoEHHTahcs\ngNRUl2tqypTSV38ni+/adHpLsug0qg7lWWdRprFQ1X2q+oSqngVcBszx+Of8l8ChIpIlIrWAc4GI\nE8MUrcFdUdSvDxMmuLTn//wnHH+8C4YbhmH4lex41uAWkQ+BYbg1GV/h3jI+UdVro76YyDRgANAI\nWAfcpqqTRGQI8BBQHXhKVe+KcLwKd0MVx/79MGkS3HKLS3/+179Co0aJVmUYBzA3VNWkot1QDVQ1\nD7dIbqqqHg3ElLFKVUeragtVra2qrVV1UrD/TVXtpKodIjUUISraDVUc1arBJZfADz+4leCdO8ND\nD0GEWZYNwzAqhPK4oSJ5s5gPnAxMAf6iqnNE5Ft1NS0Sil/eLIry/fdwww2wZAncey/Urx9g4MDs\nRMsqk/CZO37GdEaPvVlUTbx8s4hk6uztwNs419McEWkPlFjnwoDDDoM334S33oLrr4dateCJJ6B3\n70QrM6oyFbqAy6h0lPlm4WeircGdCPbuhYkTYfx46NvXxTPCEk8ahmFUGIF41OAuOEBkCnCNqm4O\ntjOA+1W1zAVz8cavbqjiyM93cYwHHoBzzoG//AVatEi0KsMwqiLxCnAfHjIUAKqaCxwRrbiqTCAQ\nIDUV/vxnWLjQrc/o1s3FNdavT7S6AyR6okCkmE5vMZ3ekQwaYyUSYyEi0jCs0RA3xdWIgcaN4b77\nYP582LHDzZz6y19g06ZEKzMMwyiZSNxQvwFuAV7AFT86G/irqsa9AFJZJJMbqiSWLXMp0F95xdXQ\nuPZaW6NhGEZ88dwNJSLVgCW4NRbrgF+BM/xgKCoLWVnw1FPw5Zewdi107OjqaPjJPWUYhlGqsVDV\n/cA/VfV7VX1EVf+hqgsqSFtE+GFRXllEou+QQ+DJJ+Grr5xLqlMn95axMuIsWeXH7/cxhOn0FtPp\nHX7XGNfcUMB7InKWVPAkbRE5RET+LSIvlnZconJDxYusLHj8cRfTqFYNevSASy+FH21li2EY5STe\nuaG24QoR7QN2BrtVVevHdMUoEZEXVfXsEvYlfcyiLDZsgEcegUcfhQED4MYb4ZhjEq3KMIxkJi5T\nZ1W1rqpWU9WaqlovuEVsKKKsu20UoXFjt6Bv6VLo3x/OPdcZjddeKz0tumEYhpdEVNtaRDJE5GgR\n6R/aorhGxHW3RWSMiDwoIpVquZoXfsy6dV3BpZ9+gt/9DsaNc7U0HnvMLfjzAr/7W0OYTm8xnd6R\nDBpjpUxjISKXAh8B7wDjcXmiciK9gKp+DOQW6T4a+ElVl6nqHmA6MFxVn1bVa1V1tYg0FJHHgJ72\n5nGAGjVg9Gg3e+rxx10Oqqwslx591apEqzMMo7ISSSLBa4DewGxVHSginYGo0ogXQ7F1t8MPUNVN\nwO/KGqiianD7rS0CqgGuvRbuuy+bCROgc+cAvXvDnXdmc+yx8OGH0Y0f6vPD96sM7VCfX/QkezvU\n5xc9JbXDtfpBT3Z2NoEKqsH9paoeJSLzgD6qulNEFqhq14gv4mHd7SLjVvoAdzRs2QKTJ7uAeHo6\nXHEFjBoFKSmJVmYYhp+IV26oFcHkga8A74rIDGBZDPrCKVfd7XAqyzoLL2jQAK65BhYvdkHxl16C\nNm3cDKqffy77fL/fxxCm01tMp3f4XWMgzjW4z1DVXFXNAW4F/g2MiOlqByhX3e1wKts6Cy+oVg1O\nOw1efx0++wxE3HTbIUNcWpG9exOt0DCMRJAdj3UWIlJPVbeWenJkx3had7vI2OaGipCdO92bxmOP\nuXxUl1wCv/0ttG5d5qmGYVQyYnFDlWYs3gMWAa8CXwYDzqGss71xbxeHqmpM9bi9IBmKH/mR775z\nM6meew769HFGY+hQqFkz0coMw4gngXIUP0JVS9yAE3Bupx+ALcHtB+BJILu0cytic/L9z6xZsxIt\noVi2b1edMkW1Xz/VZs1UR4+epYsWJVpV2fj1fhbFdHpLMuhMBo2qqsFnZ1TP27ISCX6gqr9V1S6q\n2iC4dVHVS1U1EK1VM/xFair85jfw0Ucwa5ZbEd6/P/TrB5MmwbZtiVZoGIZfSPoa3Mms34/s2eMW\n+k2cCB9+CMOHw9ixzohUi2i9v2EYfideU2d9TTJMnU0mataE0093s6YWLnRZb6++Gtq3dylGlixJ\ntELDMGIlrlNn/U4yTJ1NFmNWVGdmJlx3HXzzDfznP7B5Mxx3HPTt62ZVJaoUbLLeT79iOr3D7xrL\nM3W2rEp5NURkUUwjG5UGEejVCx5+2BVjuvlmF+M45BAYORJeftlNzTUMo/ISSbqPV4GrVfWXipEU\nORazSCybNztD8eyzMG+eMxznn+/iG9WrJ1qdYRgl4ek6i7BBPwZ6AXOA7cFuVdXTY1LpIWYs/MPK\nlTBtmlu7sW6dq7tx3nlw5JHuzcQwDP8QrwD3rcBQXHry+4D7g5sRIX73Y4Yoj85WrVwOqrlz4b33\nXP2N0aOhY0e49Vb4/nt/6KxITKe3JIPOZNAYK5HkhgoAC4H6QD1ggap+GGddAIjIcBF5QkSmi8hJ\nxR1js6H8R5cucPvtLqHh9OkunjFkCHTrBnfc4foNw6h4yjMbKhI31DnAvUDIQPQHblTVF2O6YgyI\nSDpwn6r+tki/uaGShP37YfZseP55l6OqaVM45xy3deiQaHWGUbWIV8ziW2CQqq4LtpsA76tqjyiE\nTQROA9ZpsKZFsH8wB5IJ/ltV7y7h/PuAZ1R1XpF+MxZJyL598Mkn8MILznA0bw5nnQVnn+3cVoZh\nxJd4xSwEWB/W3hjsi4aY6nCL427gzaKGIplIFjdZRemsXt3NmPrHP1wp2IcegjVrYMAAOPxw56pa\nsCDxOsuL6fSWZNCZDBpjJZKyqm8Bb4vIczgjcS7wZjQXUdWPg9Xywimoww0gIqE63H8Hng72XQ2c\nCNQXkQ6q+ng01zX8T/XqzkgMGODWcXz6qZuOe8opLkh+1llw5pnOiNisKsNIHKW6oUREcFXsegN9\ng90fq+p/o77QwaVVzwJO0XKUVjU3VOVl/3744gtnOF5+GVTdOo6RI11adctTZRixE4sbKpI3izdU\ntRvwcmyySsSTp/zYsWMLCpCnp6fTs2dPXxRIt3b52tWqwY4dAU49Fe6+O5tvv4UHHghw/vmwc2c2\nw4dDu3YBevWCk05KvF5rW9vP7UAgwOTJkwEKnpdRU1YOc2AKcHS0uc+LGScLmB/W7gO8Fda+GfhT\nlGOWlK7dVyRLjvtk0fn007P07rtV+/RRTU9XPe881RdeUM3LS7SywiTL/TSd3pEMGlXjUM8iSB9g\ntoj8LCLzg9u3sZmmQnhSh9vWWVQ9WrWCP/7RTcVdsMDV35g4EVq2dLXHn3jCBcwNwyhMIF7rLIIx\ni37A8qL7NBiYjugicarDbTELI5y8PFeL45VX4K23oFMnV49j+HC3UNAC5Ibh8HydRdBYzFcXs/Ad\nVoPbKIndu13xpldfdVudOq5Ox+mnuxTrNSKJ1hlGJSMQrxrc6mHMIh4bFrPwlMqqc/9+1a+/Vs3J\nUT3iCNWGDVUvuED1+edVN2+Oj0bVyns/E0Uy6EwGjarJF7MwjAohVI9j3Dj46iuXTv2442DyZGjd\nGk46CSZMgKVLE63UMPxLJOk+sorr1yhiFvHCYhZGedm2Dd59F2bOhNdfh8aNYdgwt/XpY3U5jMpJ\nXNJ9BI1Ca2Bg8PN2ok/3ETdsNpRRHurWhTPOcLOp1qxx/9aoAVdc4crKjhnjclht2ZJopYZRfsoz\nGyqSuEAOMBNYHGy3BD6J1t8Vjw2LWXiK6SzM8uWq//qX6qmnqtarp5qdrXrffaoLF7o4SFnY/fSW\nZNCZDBpV4xezOAMYTrBKnqquwtW1MIxKTevW8LvfOffUmjVw3XXw449w4olw6KFwzTXOhbVrV6KV\nGkb8iSRmMUdVjxaRuaraS0TSgNkaRYryeGExCyMRqMI33zgj8vrrrgrgCSe4BYGnngotWiRaoWGU\nTrzqWdwIdABOBu4CLgaeU9UJsQr1CjMWhh9Yv94tAnz9dXjnHcjKcobjtNOgd28Lkhv+I14B7ntx\nSQRfBjoCt/rBUCQTyRKAN52x0aSJC4RPnw7r1rn6HLt3w+jRAZo3h9/8xu3LzU200uLx2/0siWTQ\nmQwaYyWidayq+g7wTpy1xEROTo6t4DZ8Q40arrBT//6u7vghh8Abb8Azz8Bll0HPngfcVd26WQoS\no2IJreCOhTLdUIlCRDoD1+DySb2tqk8Vc4y5oYykYccOCAQOxDr27XNG47TTXMwjLS3RCo2qQlxi\nFolGRKoB01X1nGL2mbEwkhJVWLjQvXW8/jp8+aXLWRUyHu3aJVqhUZmJVw1uRCRVRDrFKGqiiKwV\nkflF+geLyEIR+VFE/lTCucOA14HpsVzbLySLH9N0ektpOkVcJtzrr4cPPoAVK+CSS2DuXJeKpHPn\nA/t2706cTj+RDDqTQWOslGksROR0YC7wdrDdS0SiqTsxCRhcZMzqwD+C/V2B0SLSRUTGiMiDItIC\nQFVnquoQ4MIormcYSUeDBq7e+MSJsHq1i3HUrw833wxNm7o65BMnwq+/JlqpUVWJZOrs18AJwCxV\n7RXs+06jSFteTP3tY4Fxqjo42L4JQFX/HnbOAGAkUAf4QVUfKmZcc0MZlZ5161ydjtdfd4sA27d3\nrqqhQ+HII60euRE98arBvUdVN0vhaRv7o1J2MC2BFWHtlcAx4Qeo6ofAh2UNZDW4rV0V2hdeCG3b\nBrjsMqhRI5vXX4ezzgqwdSuMGJHNaadBnToB0tL8odfa/moHKqgG90TgfGA+cCjwCPBYNDlFOLj+\n9pnAk2HtC4BHos1VguWG8hTT6S0VoXPJEtUJE1RPOcXlrzrxRNUHH1T98cfIx7D76R3JoFE1frmh\nrgIOA3YB04A84A+xmaYCVuEy2YZojXu7iBrLOmtUZdq1g6uucivIV6+GK6906Uf69TsQJA8EYM+e\nRCs1/EAgXjW4AUTkbFV9say+MsbIonDMogawCDgRWA3MAUar6g9RibeYhWEUy/79bmbVzJnw2mvw\n889wyimuTseQIZCRkWiFRiKJV26ouRoMbJfWV8r504ABuMV164DbVHWSiAwBHgKqA0+p6l3RCA+O\nbcbCMCJg9WoXIJ85071pHHHEgSJPHTsmWp1R0Xi6zkJEhojII0BLEZkgIo8Et8lAxC+1qjpaVVuo\nam1Vba1abvgdAAAgAElEQVSqk4L9b6pqJ1XtEIuhCJEMbii/6wthOr3FTzpbtIBLL4UZM9z02xtu\ngMWLITsb2rQJ8Kc/wSefuFXlfsVP97Mk/K6xPG6o0mIWq4GvgJ3Bf0PbDOCUmK4WB0K5oQzDiIzU\nVDft9vHHYeVKuOUWqFULfv97aN4cLroIXnkF8vMTrdTwmuzs7LjGLGqqqi/DY+aGMgxvWbbMvX28\n+ip88YV78xgxwrmrmjRJtDrDK+IVs1haTLeqasKz14iIjhs3jmzLOmsYnpOb63JXvfKKq9Nx+OGu\nXvmIES6brpF8BIJZZ8ePHx8XY9E4rFkHOAtopKq3Ri/VW5LlzSIQCCSFMTOd3lKZdO7cCe+/7wzH\njBkuBnLGGTByJBx2WMWkWk+G+5kMGiF+xY82hG0r1aXdOC1mlYZhJB116rgUI08+6WZWTZjg3jyG\nDoVOneCmm5zbKgl+uxkxEsmbxZFA6KBqwFHA5ap6eJy1lUmyvFkYRmVFFb7+Gv7zH3jpJfcGcuaZ\nLilinz6Wt8qvxCtmEeCAsdgLLAPuU9VFMWj0FDMWhuEfVN3q8Zdectvmzc5wnH22S7tuhsM/xMsN\nla2qA4PbSap6qR8MRTLh97nXIUynt1Q1nSKuVGxODnz3ncuQ26gRXH45tGkD114Ls2fH7qpKhvuZ\nDBpjpcSssyJyffBj0T+t4GZDPRA3VVFgNbgNw5906QK33ea2BQvghRfg4ovd+o1zzoHRo6FXL6tD\nXpGEZkPFQoluKBHJ4WBDAQeMxfiYrhgFIpIGBIAcVX29mP3mhjKMJEIV5s+H6dNh2jSoXRtGjYLz\nzrO0IxVJpavBLSLjga244kdmLAyjEqEKn3/ujMbzzztX1fnnO+ORmZlodZWbuMQsRKS1iPxXRNYH\nt5dFpFUUomKqwS0iJwELgPWRXsuvJIsf03R6i+ksHRE3Y+rhh13akTvvhK++cqnVhwxxRiQ85Ugy\n3M9k0BgrkcxPmITLB9UiuM0M9kVKrDW4BwB9gPOAS0XMs2kYlZUaNeDkk2HqVFi1CsaMgSlToGVL\nuOQS+OgjW8ORaCKZOvtN0TUVxfWVMUYWUdbgDjv3QmC9qr5RzD5zQxlGJWb1anj2WWc4du6EsWPh\nwguhdesyTzVKIV41uDeKyBjgOVxwexSwIQZ94ZRZgzuEqk4pbSCrwW1ta1fu9o03ZnPDDfD44wHe\neAMefDCb3r3h2GMDHHccnHSSv/T6sR0IVEwN7iyc62l9cHsVaBNN7VasBneiJUSE6fQW0+ktIZ35\n+arPPKOana3atKnqjTeqLlqUWG0hkuVeEo8a3Kq6TFWHqWqT4DZcVZfHZpoKsBrchmHEREqKmzU1\naxZ8/LHr69cPTjjBrRy3euMlE4hzDe57gTuAHcBbwOHAtar6dMQXsRrchmHEkd27XX6qRx+FJUvg\nt7+Fyy5zAXLjYOIydRY4WVXzgKG4vFDtgRujEDUN+BToKCIrROQiVd0LXAm8jZse+3y0hsIwDCNE\nrVpufcZHH8Hbb8OGDdC9u+srT4oR4wCRGItQEHwo8JKqbqH4ld3FolaD2/f6QphObzGd3hKpzm7d\n4J//hKVL4dhj3TTco4+GZ56Jv4vK7/eyPG6oSIzFTBFZCBwJvC8iTXF1uX2B1eA2DKM4GjSAa66B\nRYtg3DiYNAnatYP77oMtWxKtLjFkx7MGN4CINAS2qOq+YL6m+qq6JqYreojFLAzDiIavv4b774e3\n3oKLLoLrrnNV/6oa8Ur3kQJcBLwkIv8BLgNyY5PoPcnghjIMwx8ccYRb5Dd3Luzb51xWv/sd/Pxz\nopVVDPF2Q03FpeSYgEvRcRgQ8UyoeJMMbqhkMWam01tMp7d4qbNNG3jwQeeiatzYxTTGjHHt8uD3\ne1keN1QkxuIwVb1EVWep6geq+lucwTAMw0hqmjRxCQyXLHEJDI8/3qUT+emnRCvzH5Gss3gG+Keq\nzg62+wBXqOqYCtBXKhazMAzDS7ZscVlwJ0yA4cNd4aa2bROtyns8jVmIyPxgWvEjgU9E5BcRWYZb\nM3FUuZQahmH4kAYNnIH48UcX+D7iCLjhBti0KdHKEk9pbqhhwW0I0A6XMjw7+HlI3JVVIvzuxwxh\nOr3FdHpLRerMyIA77nC1xLdtg06d4J57YMeO0s9LlnsZCyUai2BOqIINyAf2h22GYRiVmubN4bHH\nXA6q2bOha1eXVqQqer8jiVmcDtyPK3y0DmiLK3Ma1yC3iGTjclJ9B0xX1Q+LOUbHjRtHdna272dE\nGYaR/HzwAVx9NTRr5mIbhyXZVJ9AIEAgEGD8+PHe1+AWkW+BE4B3VbWXiAwExqjqxbFLjkCYSH/g\nJuBX4K+quqSYYyzAbRhGhbJ3r3vbuP12l/329tuhXr1Eq4qOeCUS3KOqG4BqIlJdVWcRRYA71hrc\nwMeqeirOYIyP9Hp+JFn8mKbTW0ynt/hFZ40acOWV8P33kJvrFva9/rrb5xeN8SASY5ErIvWAj4Fn\nRWQCsC2Ka8RUgzvslWEzUDuK6xmGYcSdJk1g8mR46innmho1qnLPmorEDZWGSxxYDTgfqA88q6ob\nI75IDDW4ReQM4BQgHXhUVT8qZlxzQxmGkXDy8507atIkeOQROOecRCsqnVjcUBElEiwvxRiLs4BT\nVPXSYPsC4BhVvSrKcc1YGIbhG+bMgQsugGOOgX/8w63b8COxGIsaZR8SFzx7wo8dO7agAHl6ejo9\ne/b0RYH08Haozy96Smo/9NBDvrx/dj/j2w71+UVPMt/PefPmMXfuH7jhBujUKcDNN8M11yReXyAQ\nYPLkyQAFz8uoibZodywbkAXMD2v3Ad4Ka98M/CmGcTUZSJYi7qbTW0yntySDznCNr72m2ry56u23\nq+7blzhNxRF8dkb1vI20nkUtoAtuMd4iVd0djUGKZw1uW2dhGIZfWb3axS/S0+Hpp93K8EQSiPM6\ni9OAx4BQxvd2wP+p6hsRXcDV4B4ANMIt6rtNVSeJyBDgIaA68JTGUFrVYhaGYfidPXvgj3+EGTPg\n5ZehZ89EK4rfOosHgIGqOkBVQ/mhHoz0Amo1uH2vL4Tp9BbT6S3JoLM4jTVrutoZf/sbnHQSPP98\nxesKEShH8aNIAtx5qhqe3f1nIC+mq8WBWL+4YRhGRXLuudClCwwdCitWwPXXg0T12778hFz248dH\nv845EjfUY0Ab4IVg19nAcuBdAFX9T9RX9QhzQxmGkWysXAlDhkB2Njz0EFSvXvEa4rLOQkQmBz+G\nDpSwz6jqRdFc0EvMWBiGkYxs3gwjR7p1GM8+C6mpFXv9uMQsVHVscLsouIV/TpihCGExC+8wnd5i\nOr0lGXRGqjE9Hd56yxmJ005zK8ArgrjELETkT6p6t4g8UsxuVdWrY7qix1jMwjCMZKRWLZg6FcaO\ndSVcZ86EOnXie824xCxEZJiqzhSRC4vuwhmLKdFL9RZzQxmGkezs3QtjxjjX1CuvQO0KSJvqecwi\nmB32HlW9vrzi4oEZC8MwKgN797qstbt2ubUYtWrF93qexyxUdR/QV6SiJ3hVLpLB1wqm02tMp7ck\ng85YNdaoAdOmuX/HjPFn2dZIFuXNA14N1po4M7iNjLcwwzCMqkTNms5gLF8Od96ZaDUHE+nU2YMO\nivdMqODbzJ1APeBLVZ1azDGWG8owjErFmjUuxfnDD8MZZ3g7drxzQx2vqv8rq89rgsWPhgMbgDdU\n9YNijrGYhWEYlY4vv3QL9z74ALp39378eOWGmhBhX7GUowZ3R+ATVb0BuDzS6/mRZPC1gun0GtPp\nLcmg0yuNRx3l3iyGD4cNGzwZstyUts7iWOA4oKmIXIebMgvOLRTNAvVJwCNAgRsprAb3IGAV8IWI\nzACOAo4A7gVWAqFU6PujuJ5hGEbSc955MH++myX1zjtQLZKf9sUQ8r6Ud55SaessBgADgf/DpSgP\nsRVXm+LHiC8SWw3uFJyRyQd+UNV/FTOuuaEMw6i07NsHxx8PF14Iv/tdbGP8c84/2ZC/gXHZ4wr6\nPC2rqqofAh+KyGRVXRabzBJpCawIa68Ejily/R3Abz2+rmEYRtJQvTr8+98u6eDQodCqVXTnL9yw\nkJwPc/jk4k/KraXMFOVxMBRgNbh9pS+ZahyHsPtp9zPReoprz5s3jz/84Q+ej3/VVXD22QH+9jcY\nODCy8997/z2ueOMK7hh9B6vnr+Zvk/8GWA1uX5MMtYNVTafXmE5vSQad8dK4a5dqt26qzz0X+Tl/\nef8veuqzp+r+/fsP2ke8anCXF6vBbRiGUT7mzIHTT4fvvoPGjUs/dvaK2Zzx/BnM+908mtVtVtAf\niMc6iyLZZpUDs6EgiqyzVoPbMAzDG667Dtatg2eeKfmYbbu30fOxntxz0j2M7FJ8sg2v11l8Fdxq\n46azLgZ+BHoCEae5UqvB7Xt9IUynt5hOb0kGnfHWeMcdEAjA3LnF78/fk8+Y/46hX9t+xRqKQDnq\nWZRoLFR1sqpOBg4HBqrqI6o6ATgB6BXT1eJATk6OuaAMw6gSpKXBNdfA/fcfvG9l3kr6T+pPas1U\nHj310WLPz87OjtlYRJLuYxFwnKpuDLYbArNVtVNMV/QQc0MZhlHV2LIF2rVzbxdt2ri+z1d+zsgX\nRnLV0Vfxp75/KnMBXrzSffwd+FpEpojIFOBrIGa3kWEYhhE7DRrARRe5dCCqyqS5kxg6bSiPnfYY\nNx1/U7lXapdEJDW4J+Gmuv4X+A/QJ+ie8gUWs/AO0+ktptNbkkFnRWm85hp48rW59P33AB7+/GE+\n+M0HDOs0rMzz4hKzKOa49cBmoKOI9I/panHAYhaGYVQl1m9fz53z/o895wym+frz+eqyr+ieGVlq\n2njHLO4GzgUWAPtC/apathmLMxazMAyjqrB662oe/uxhnpr7FBf0uIAzMsZx/pkZ/Pxz9GVYPc0N\nFcYZQCdV3RWdHMMwDKO8fL/ue+6bfR+vLnyVMT3G8OVlX5KVngVA587w/POuFGu8icQNtYQo1lUY\nB5MMvlYwnV5jOr0lGXR6pfHXbb8y4fMJHPvUsQx6ehCHNjyUn67+iYeHPFxgKABuuAHuvbdianZH\n8maxA5gnIu8DobeLiFdwG4ZhGGWzMm8lry1+jZd/eJkvV3/JsI7DGDdgHCceciI1q9cs9pxTToE/\n/AG++AKOPjq++iKJWYwtpltVdUpcFEWB5YYyDCNZ2bd/H1+t+Yo3fnyDGYtm8MuWXxjSYQgjOo/g\ntENPI6VmSkTjXHQRHHssXHZZ2cfGJTdUohGR44HzcW8/XVW1bzHHWIDbMIykQFVZvHExHyz9gPeW\nvsespbNoWb8lp7Q/hdM7nc5xrY+jRrVInD2FeeABWLoUHnmk7GNDxGVRnogsLWb7OZqLxIKq/k9V\nLwdeAybH+3rxJBl8rWA6vcZ0eksy6AzXuG33Nj5c9iF//9/fOX3a6TS5twknPX0Sn636jDM6n8H3\nv/+e+ZfP576T76N/2/4xGQqA7t1dJtp4E4m63mGf6wBn4TLIRoSITAROA9aFUpQH+wdzIOvsv1X1\n7hKGOA+4ONLrGYZhVDRbd23lu3XfMWPRDJ7e8jRzVs/h59yf6da0G8e1Oo4xPcbw6GmP0qp+lKXu\nIqB7d1erWxXitHgbiNENJSJfq+oRER7bD9gGTA2rZ1EdV89iELAK+AIYDRyFy3B7r6quFpE2wF9U\ntVhvnLmhDMOoSPbs28OijYv4bt13fLfuO+avm8/8tfNZu30tXRp3oUdmD3q36E3vlr3pkdmDWtXj\nP5FUFZo0cQajefPIzonLOgsROZIDZVCr4R7o1SO9gKp+HCx+FM7RwE8aLNkqItOB4ar6d+DpsOMu\nBiZGei3DMIzyoqpsyN/AktwlLN64mIUbFrJo4yIWbljIz7k/07ZBW7o17Ua3pt24oPsF9BjUgw4N\nO1C9WsSPRU8ROfB2EamxiIVI3FD3c8BY7AWWAeeU87otgRVh7ZXAMUUPUtWcsgayGtxVq8ZxCLuf\ndj/LM97e/Xt56Y2XWL11NXU71uWnTT8x++PZrNm2hnVN1lGzek0ar2tM6/qtGTBgAKMOG8XWRVtp\n1akVJ5948oHx1kOnwzoVtONVg7usdvfu8MorAWrVKn5/IBBg8uTJQOw1uBNVVvVMYLCqXhpsXwAc\no6pXRTluUrihAoFAwR/Qz5hObzGd3hKNzvw9+SzfspxfNv/Css3LWLZ5Gb9s+YXlW5azfMtyft32\nK03TmtK+YXs6ZHSgQ8MOtG/YnvYZ7WnfsD3pddLjrtFLnnwSPv0UJk2K7PhY3FCRrLNIB8YBoeSB\nAeB2Vd0S8UUONhZ9gBxVHRxs3wzsLyXIXdK4ts7CMKoQqkruzlxWb13N6q2rWbN1DWu2reHXbb+y\nIm9FgYHI25VH6watyUrPIqtBFlnpWbRp0Ia26W1p06ANLeu1LHGhWzIyezZcdRV8+WXpxwXiuc5C\nRP4DzAem4OpwjwF6qGrxxV2LHyOLwsaiBi7AfSKwGpgDjFbVH6ISnyRvFoZhlM7ufbtZt30dv277\n9aBt7fa1/Lrt1wIDUbt6bVrUa0GLei1oXq85zeu6rVX9VgUGoWlaU6pJpEm1k5+tW6FZM8jLg+oR\nhE7i9WbxjaoeXlZfKedPAwbgptuuA25T1UkiMoQDU2efiqUOd7IYi8r4mp9ITKe3xEtn/p581m9f\nz7rt61i7fa37d9vagna4IcjblUfTtKY0q9uMZnWbkZmWSfO6zcmsm1nQXvntSkYMHkFarTTPtXpF\nIv/mhxwCb78NHTsW7v/lF9ixwyUdDBGvrLM7RKSfqn4cvMjxQH6kF1DV0SX0vwm8Gek4JRGqZ5EM\n/1MaRrKyX/ezZecWNu7YWGAAwrcNOzawMX8jG3dsZGP+Rtbnr2fPvj00TWtKk7QmZKZlklk3k6ap\nTWndoDVHtjiywAg0q9uMRqmNynwTCCwL+NpQJJrQ4ryixmLCBFe7+/bbD7ihYiGSN4uewFSgQbAr\nF7hQVb+J6YoekixvFobhJ/bt38fmnZvJ3ZnLph2b2Ji/kQ35G9iQv6HAGGzY4drrt69nQ/4Gcnfm\nklYzjUapjWic2pjMtEyapjV1xiC1CY1TG9MotRGNUhrRKLURTdOaUq9WvbiV+DQO5s9/htq1Ydy4\nA33790Pbtu6No2vXA/1xebNQ1XlADxFpgJtCuxU3dTbhxsIwqjKqSt6uPDbucA/70EN/045NBb/w\nN+3cxKYdB7aN+RvZunsr9WvXJ6NOBhkpGTRObUzj1MY0SW1Co5RG9Greq3Bf0AhUpoBwZaR7d3j5\n5cJ9n34KGRmFDUWslGgsRKQu8H9Ae+A74DFgOPBX4Cfg+fJfvvwkgxuqqvuuvaay6dy7fy+5O3LZ\nuGMjuTvcr/3Qr/5QO/yhH35MnRp13K/6lEaFf92nNKJz4840Sm1Ew5SGBVtGnQzS66QXWkBW2e5n\nIkmkxu7doWjF1OnTYdSoA+3yuKFKe7OYCuQBs4GTgbHATuC84NuGL4i1nqxheImqsmPvjkK/4D/+\n5WOWfL2E3J255O7ILTAAhX7p79jI9t3bSa+TTkZKBo1SGpGRklHwYG+U0ohDMg7hyJQjXTv48A+9\nFVREOgkjOejYEZYvd8HslBTYuxdefNG9XYQI/bAeP3581OOXGLMQkW9VtUfwc3VgDdBWVXfE8kXi\ngcUsDK/Zs29PwcN9446NhR7+4Q/73J25zu+/w/27eedmgIJf9uEP/NCDPfxhX2AMUhtRv3b9KjXN\n04gf3bvDlClwxBHw3ntw882uMFJRvI5Z7At9UNV9IrLKT4bCMEpCVdm+Z3vB7Jyiv+bDt3B3T+7O\nXHbv2+1+5Rf3YE9pRMdGHQv9sg8d26BOA1Jrpib6qxtVnFCOqCOOONgFVV5KMxY9RGRrWDslrK2q\nWt87GZWbZPC1gv907t2/l807Nxf6db9pxybmfDKHxl0bF8zoKc69U6NajYKZOQU++zru36ZpTenS\nuEvhX//BX/51a9X1bAaP3+5nSZhO70i0xpCx2L0bXnml8Myo8lKisVDVxKRQNCod+3U/uTtyWZ+/\nvuCBX1IAN7R/446NbN21lQZ1GtAopXCQdnvedjI0gzYN2tAjs0fBQz90XEZKBnVq1En01zaMCqd7\nd1cx7913oUsXaN3au7F9W1Y1Eiw3VMWjqmzeuZn1+W5hVviUzdA8/fCpm6F23Vp1C+bjhx7oDes0\nLAjqFrh7gu1GqY1Ir5NuvnzDiIJly6BvXzjhBOjTB664ovD+uOaGShQi0gqYgFsEuLi4JIMW4C4/\noYDuph2b2JC/gbXb1hakYCgwBkXm8afUTCm0GCs0dTO0YCv0Kz/Utjn6hlExqEKD4PLpH3+EzMzi\nj4tXuo9E0R14WVWfDRZHSloqyo+pqmzZtcXl3Ak+9MPz8RQN9ubuzGXn3p2k10mnYUpDavxSg45H\ndaRZWjMy62bSI7PHQXP4m6Q2oXaN2nH/LqWRaL9wpJhOb0kGnYnWKALdurn0HiUZiliJu7EoRw3u\nT4EZInIxhavnVSn27t/L2m0Hfumvz1/P+u3rWZ+/vsAYhBuE2jVqF+ThyUzLLEjL0LNZz4Jf/eEu\nn/CUDIn+D90wjPIzZEjhpIFeEXc3VKw1uHEpRb4KlmV9UVXPLmbspHRDqSrbdm8rNhVz6I0glI55\nff56Gqc2plndZgWunyapTQonZwvm6MlMyySlZkqiv55hGD7Hl26oWGtwi8gHwG0ich6wNN46vWLr\nrq2s3rqaFXkrWLHFFWNZtXVVIZfQ2u1rAWhet3lBSuZQBs7eLXvTNK1pQb7+ZnWbUaOan72FhmFU\nBRL1FCqzBreqfgucVZGiSmPn3p2s3rqalXkrWb11NavyVrlf/9sKV+zat38fLeq1oHWD1rRp0IbW\n9VuTtiqNsQPGFrwFZKZlUq92vUR/pYNIFjeU6fQW0+kdyaAxVhJlLDzzHY0dO7agAHl6enpMBd37\n9e/H6q2reeWtV/h126/U61SPFVtWMPezuazbvo4tzbeQtyuPjF9dhs6uvbvSsl5Ldvy4g3ap7bjs\nhMtoXq85P339E2k10xg4cGCh8ekM2V1c0fSVrKRDdoeo9FVUe968eb7SU1I7hF/02P2smHYy3M95\n8+b5Sk+oHQgEmDx5MkDB8zJaKmTqbCJrcKsq67av4+fcn1mSu4QVW1awZtsa9zawbQ2r8laxZtsa\nGqc2pm0DV5839EbQukFrWtdvTav6rWiS1sTm/BuGkdQE/L7OIt41uHfv283KvJX8svkXluQu4ceN\nP/JT7k/8uPFHluQuIaVGCu0y2tG+YXta1299oH5v3eYFLiPL3mkYRlUhLjW4y0u8a3C3uL8FG/I3\n0Lxuc9o0aEP7hu3pkNGBQxsdSoeGHWif0Z4GdRqUPVgcCSSJH9N0eovp9JZk0JkMGsG/s6HiWoP7\nnHXnMPTkoZx4wonlHcowDKNSE3JDxYJv031EQrKuszAMw0gksbxZWMTWMAzDKBMzFhVArK99FY3p\n9BbT6S3JoDMZNMZK0huLnJycSv0HMgzD8IpAIEBOTk5M51rMwjAMo4phMQvDMAwjLpixqACSxU1m\nOr3FdHpLMuhMBo2xYsbCMAzDKBOLWRiGYVQxKlXMQkS6isjzIvKoiJxZ0nE2G8owDCMyyjMbyrfG\nAhgMPKKqvwd+U9JBOTk5vs/FkizGzHR6i+n0lmTQ6XeN2dnZ/jUWIjJRRNaKyPwi/YNFZKGI/Cgi\nfyrm1KeBUSJyDy4JYdISysPvd0ynt5hOb0kGncmgMVYq4s1iEu4toYBgDe5/BPu7AqNFpIuIjBGR\nB0WkhaquV9UrgZuBDRWgM25s3rw50RIiwnR6i+n0lmTQmQwaY8XPNbjbAn8G0oB74q3TMAzDKBk/\n1+D+Bfi/ihQVL5YtW5ZoCRFhOr3FdHpLMuhMBo2xkqhKeWcCg1X10mD7AuAYVb0qynFt3qxhGEYM\n+K74UQmsAlqHtVvj3i6iItovaxiGYcRGoqbOfgkcKiJZIlILOBeYkSAthmEYRhlUxNTZacCnQEcR\nWSEiF6nqXuBK4G1gAfC8qv4Qby2GYRhGbMTdWKjqaFVtoaq1VbW1qk4K9r+pqp1UtYOq3lXWOMWt\n1xCRhiLyrogsFpF3RCQ9nt8lEkSktYjMEpHvReQ7Ebnaj1pFpI6IfC4i80RkgYjc5UedQU3VRWSu\niMz0scZlIvJtUOccH+tMF5GXROSH4N/9GL/pFJFOwfsY2raIyNV+0xnUenPw//X5IvKciNT2qc5r\nghq/E5Frgn1R6fTzCu6iHLReA7gJeFdVOwLvB9uJZg9wraoeBvQBrhCRLvhMq6ruBAaqak+gBzBQ\nRI7HZzqDXIN7Aw1NaPCjRgWyVbWXqh4d7POjzoeBN1S1C+7vvhCf6VTVRcH72As4EsgH/ovPdAYn\n7lwKHBGcvFMdGIX/dHYDfgv0Bg4HhopIe6LVqapJswFZwPyw9kIgM/i5GbAw0RqL0fwKMMjPWoFU\n4AvgML/pBFoB7wEDcTPqfPl3B5YCjYr0+Uon0AD4uZh+X+ksou1k4GM/6gQaAouADNxkoZnAST7U\neRbw77D2X4A/Rqszmd4siiNTVdcGP68FMhMppijBXx69gM/xoVYRqSYi84J6Zqnq9/hP54PAjcD+\nsD6/aQT3ZvGeiHwpIpcG+/ym8xBgvYhMEpGvReRJEUnDfzrDGQVMC372lU5V3QTcDywHVgObVfVd\nfKYT+A7oF3Q7pQKn4n6ERaUz2Y1FAerMo2/WXYhIXeBl4BpV3Rq+zy9aVXW/OjdUK6C/iAwssj+h\nOkVkKLBOVecCxU6TTrTGMPqqc5sMwbke+4Xv9InOGsARwKOqegSwnSKuB5/oBCA4U3IY8GLRfX7Q\nGXTl/AHn8WgB1A2uGSvADzpVdSFwN/AO8CYwD9hX5JgydSa7sVgrIs0ARKQ5sC7BegAQkZo4Q/G0\nqtdWvL8AAAURSURBVL4S7PalVgBV3QK8jvMP+0nnccDpIrIU9+vyBBF52mcaAVDVNcF/1+P860fj\nP50rgZWq+kWw/RLOePzqM50hhgBfBe8p+O9+HgV8qqob1c3w/A9wLD68n6o6UVWPUtUBQC6wmCjv\nZ7IbixnAhcHPF+LiAwlFRAR4Cligqg+F7fKVVhFpHJr9ICIpOF/rXHykU1X/rG4G3SE4d8QHqjrG\nTxoBRCRVROoFP6fh/Ozz8ZlOVf0VWCEiHYNdg4Dvcb523+gMYzQHXFDgs/uJ8/n3EZGU4P/3g3AT\nMXx3P0WkafDfNsBI4DmivZ+JDLxEGaSZhvML7sbllboIF2B6D2cl3wHSfaDzeJx/fR7u4TsXN4vL\nV1qB7sDXQZ3fAjcG+32lM0zvAGCGHzXiYgHzgtt3wM1+1BnUdDhuMsM3uF/CDXyqMw2XbbpeWJ8f\ndf4RZ3DnA1OAmj7V+VFQ5zzcLMio72dSl1U1DMMwKoZkd0MZhmEYFYAZC8MwDKNMzFgYhmEYZWLG\nwjAMwygTMxaGYRhGmZixMAzDMMrEjIVRaRGRESKyX0Q6hfVlSTDNvYgcLiJDwvYNE5E/hZ3bJYZr\nBkTkyCjPuU9Esovpz5ZgWvZYEJH3Q4sFDaO8mLEwKjOjgdeC/xZHL1xSNQBUdaaq3h1sjgC6xnDN\nqHIBBR/m/VU1EMO1ymI6LoW2YZQbMxZGpSSYyPEYXEXGc4vZXxO4HTg3WGDnHBEZKyKPiMixuAR2\n9wazs7YLf2MIpkpZGvycIiLTxRUS+g+QEnaNk0XkUxH5SkReCKYCKcpw3Cra0DmDxRUm+go4I6w/\nTVwBsM+Dmk4P9qcGx/5eRP4jIp+FvdnMwKVJMYxyY8bCqKwMB95S1eW4tNxHhO9U1T3ArcB0dYV2\nXiD4RqCqs3EP2htU9QhV/ZmS3xguB7apaldgHC4ZIyLSGLgFOFFVjwS+Aq4r5vy+uJr0iEgd4Alg\naPCcZmHXvAV4X1WPAU7AGbJU4PfARnXFtm4NXj/0PdYCjUswUoYRFWYsjMrKaA6ktn6R4l1RQgmp\nz8P2l0U/4BkAVZ2Py7MFrkpiV+BTEZkL/AZoU8z5bYE1wc+dgaWquiTYfiZMw8nATcGxZgG1g+P1\nxbmbUFePJHT9EGuB1hF8D8MolRqJFmAYXiMiDXGV9bqJiOLKXSquiFI0hL9J7OXAj6s6RS9ZQvtd\nVT0vguuU9KOt6LgjVfXHQgeIFHdc0TEsAZxRbuzNwqiMnAVMVdUsVT1EVdsAS4sWJALygPDZQuEP\n3a1A/bD2Mlz9gtD4IT4CzoOCWsc9cA/nz4C+wQI5oZjDocVo/QXnbgKX8jpLRNoF2+FvQ28DVxcI\nFekV/PgJcE6wrysum3A4mbg6FoZRLsxYGJWRUbgCROG8HOwPjz3MArqGAtxF9k0HbgwGpw8B7gMu\nF5GvgUZhx/0LVyFtATCeYPxBVTcAY4FpIvIN8ClQMIU3jP8RNEKquhO4DHg9GOBeG3adO4CaIvKt\niHwXvBbAo0ATEfk+eMz3wBaAYGGbjaq6PaK7ZhilYCnKDSOBBGdtzVLV3jGeXw2oqaq7gm8x7wId\nVXWviFwGpKnqgx5KNqooFrMwjASiqttEZJaIDFTVWTEMkQZ8EJwKLMDl6kp8gpsyPNwrrUbVxt4s\nDMMwjDKxmIVhGIZRJmYsDMMwjDIxY2EYhmGUiRkLwzAMo0zMWBiGYRhlYsbCMAzDKJP/B4UxHNgm\ncctJAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x109c1a410>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(alt_in.to(u.deg).value, np.abs((altaz_out.alt - alt_in).to(u.arcsec).value), label='Altitude Error')\n",
+    "plt.plot(alt_in.to(u.deg).value, np.abs((altaz_out.az - az_in).to(u.arcsec).value), label='Azimuth Error')\n",
+    "plt.legend()\n",
+    "plt.xlabel('Altitude (deg)')\n",
+    "plt.ylabel('Round trip absolute error (arcsec)')\n",
+    "plt.yscale('log')\n",
+    "plt.grid()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print a table of round-trip errors suitable for pasting into a docstring:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Altitude (deg) Error (arcsec)\n",
+      "============== ==============\n",
+      "          10.0        -15.175\n",
+      "          15.0         -1.891\n",
+      "          20.0         -0.425\n",
+      "          25.0         -0.130\n",
+      "          30.0         -0.048\n",
+      "          35.0         -0.020\n",
+      "          40.0         -0.009\n",
+      "          45.0         -0.004\n"
+     ]
+    }
+   ],
+   "source": [
+    "errors_table = astropy.table.Table([\n",
+    "        astropy.table.Column(name='Altitude (deg)', data=alt_in[:40:5].to(u.deg)),\n",
+    "        astropy.table.Column(name='Error (arcsec)', data=(altaz_out.alt - alt_in)[:40:5].to(u.arcsec), format='.3f')\n",
+    "    ])\n",
+    "astropy.io.ascii.write(errors_table, format='fixed_width_two_line', position_char='=')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -112,7 +112,6 @@ def test_invalid_frame():
 
 
 def test_altaz_roundtrip():
-    ra, dec = 0.5 * u.rad, 1.5 * u.rad
     where = observatories['APO']
     when = Time(56383, format='mjd')
     wlen = 5400 * u.Angstrom

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -126,6 +126,24 @@ def test_altaz_roundtrip():
     assert np.allclose(sky_in.dec, sky_out.dec)
 
 
+def test_altaz_array_roundtrip():
+    where = observatories['APO']
+    when = Time(56383, format='mjd')
+    wlen = 5400 * u.Angstrom
+    temperature = 5 * u.deg_C
+    pressure = 800 * u.kPa
+    obs_model = create_observing_model(where=where, when=when,
+        wavelength=wlen, temperature=temperature, pressure=pressure)
+    sky_in = SkyCoord(
+        ra=(1+np.arange(10))*u.deg, dec=(1+np.arange(10))*u.deg, frame='icrs')
+    altaz_out = sky_to_altaz(sky_in, obs_model)
+    sky_out = altaz_to_sky(altaz_out.alt, altaz_out.az, obs_model, frame='icrs')
+    assert np.allclose(
+        sky_in.ra.to(u.deg).value, sky_out.ra.to(u.deg).value, atol=0.015)
+    assert np.allclose(
+        sky_in.dec.to(u.deg).value, sky_out.dec.to(u.deg).value, atol=0.010)
+
+
 def test_adjust_null():
     ra = 45 * u.deg
     when = Time(56383, format='mjd', location=observatories['APO'])

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -3,7 +3,7 @@
 from astropy.tests.helper import pytest
 from ..transform import altaz_to_focalplane, focalplane_to_altaz, \
     observatories, create_observing_model, sky_to_altaz, altaz_to_sky, \
-    adjust_time_to_hour_angle
+    adjust_time_to_hour_angle, low_altitude_threshold
 
 import warnings
 import numpy as np
@@ -123,11 +123,8 @@ def test_alt_no_warn():
                                        pressure=pressure)
     # The pytest 2.5.1 bundled with astropy_helpers does not implement
     # pytest.warns, so we turn the warning into an exception.
-    warnings.simplefilter("error")
-    altaz_to_sky(4*u.deg, 0*u.deg, obs_model)
-    # Corresponds to alt=4deg, az=0deg, as used above.
-    sky = ICRS(ra=263.65021762*u.deg, dec=59.50265906*u.deg)
-    sky_to_altaz(sky, obs_model)
+    warnings.simplefilter('error')
+    altaz_to_sky(low_altitude_threshold - 1*u.deg, 0*u.deg, obs_model)
 
 
 def test_alt_no_warn_pressure_array():
@@ -139,8 +136,9 @@ def test_alt_no_warn_pressure_array():
                                        pressure=pressure)
     # The pytest 2.5.1 bundled with astropy_helpers does not implement
     # pytest.warns, so we turn the warning into an exception.
-    warnings.simplefilter("error")
-    alt = np.array([4., 6.]) * u.deg
+    warnings.simplefilter('error')
+    alt0 = low_altitude_threshold.to(u.deg).value
+    alt = np.array([alt0 - 1, alt0 + 1]) * u.deg
     altaz_to_sky(alt, 0*u.deg, obs_model)
 
 
@@ -153,13 +151,10 @@ def test_alt_warn():
                                        pressure=pressure)
     # The pytest 2.5.1 bundled with astropy_helpers does not implement
     # pytest.warns, so we turn the warning into an exception.
-    warnings.simplefilter("error")
+    warnings.simplefilter('error')
     with pytest.raises(UserWarning):
-        altaz_to_sky(4*u.deg, 0*u.deg, obs_model)
-    with pytest.raises(UserWarning):
-        # Corresponds to alt=4deg, az=0deg, as used above.
-        sky = ICRS(ra=263.65021762*u.deg, dec=59.50265906*u.deg)
-        sky_to_altaz(sky, obs_model)
+        altaz_to_sky(low_altitude_threshold - 1*u.deg, 0*u.deg, obs_model)
+
 
 def test_alt_warn_pressure_array():
     where = observatories['APO']
@@ -170,15 +165,15 @@ def test_alt_warn_pressure_array():
                                        pressure=pressure)
     # The pytest 2.5.1 bundled with astropy_helpers does not implement
     # pytest.warns, so we turn the warning into an exception.
-    warnings.simplefilter("error")
-    alt = np.array([6., 4.]) * u.deg
+    warnings.simplefilter('error')
+    alt0 = low_altitude_threshold.to(u.deg).value
+    alt = np.array([alt0 + 1, alt0 - 1]) * u.deg
     with pytest.raises(UserWarning):
         altaz_to_sky(alt, 0*u.deg, obs_model)
-    '''
-    alt = np.array([4., 6.]) * u.deg
+    alt = np.array([alt0 - 1, alt0 + 1]) * u.deg
     with pytest.raises(UserWarning):
-        altaz_to_sky(alt[:, np.newaxis], 0*u.deg, obs_model)
-    '''
+        print altaz_to_sky(alt[:, np.newaxis], 0*u.deg, obs_model).shape
+
 
 def test_altaz_roundtrip():
     where = observatories['APO']

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -203,14 +203,11 @@ def test_altaz_array_roundtrip():
     pressure = 800 * u.kPa
     obs_model = create_observing_model(where=where, when=when,
         wavelength=wlen, temperature=temperature, pressure=pressure)
-    sky_in = SkyCoord(
-        ra=(1+np.arange(10))*u.deg, dec=(1+np.arange(10))*u.deg, frame='icrs')
-    altaz_out = sky_to_altaz(sky_in, obs_model)
-    sky_out = altaz_to_sky(altaz_out.alt, altaz_out.az, obs_model, frame='icrs')
-    assert np.allclose(
-        sky_in.ra.to(u.deg).value, sky_out.ra.to(u.deg).value, atol=0.015)
-    assert np.allclose(
-        sky_in.dec.to(u.deg).value, sky_out.dec.to(u.deg).value, atol=0.010)
+    alt_in, az_in = np.linspace(20., 89., 70) * u.deg, 90. * u.deg
+    sky = altaz_to_sky(alt_in, az_in, obs_model)
+    altaz_out = sky_to_altaz(sky, obs_model)
+    assert np.all(np.abs(altaz_out.alt - alt_in) < 0.5 * u.arcsec)
+    assert np.all(np.abs(altaz_out.az - az_in) < 1e-5 * u.arcsec)
 
 
 def test_sky_to_altaz_shape():

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -198,42 +198,28 @@ def focalplane_to_altaz(x, y, alt0, az0, platescale=1):
     return alt * u.rad, az * u.rad
 
 
-def sky_to_altaz(sky_coords, where, when, wavelength, temperature=15*u.deg_C,
-                 pressure=None, relative_humidity=0):
-    """Convert sky coordinates to (alt,az) for specified observing conditions.
+def create_observing_model(where, when, wavelength, temperature=15*u.deg_C,
+                           pressure=None, relative_humidity=0):
+    """Create a model for observations through the atmosphere.
 
     This function encapsulates algorithms for the time-dependent transformation
-    between RA-DEC and ALT-AZ, and models the wavelength-dependent atmospheric
-    refraction. For example, to locate Polaris from Kitt Peak:
-
-    >>> where = observatories['KPNO']
-    >>> when = astropy.time.Time('2001-01-01T00:00:00')
-    >>> polaris = astropy.coordinates.ICRS(ra=37.95 * u.deg, dec=89.25 * u.deg)
-    >>> altaz = sky_to_altaz(polaris, where, when, 5400 * u.Angstrom)
-    >>> print('alt = %.3f deg, az = %.3f deg' %
-    ... (altaz.alt.to(u.deg).value, altaz.az.to(u.deg).value))
-    alt = 32.465 deg, az = 0.667 deg
-    >>> print('lat = %.3f deg' % where.latitude.to(u.deg).value)
-    lat = 31.963 deg
+    between sky coordinates and ALT-AZ through a specified atmosphere, and
+    models the wavelength-dependent atmospheric refraction.
 
     The output shape is determined by the usual `numpy broadcasting rules
     <http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`__ applied
-    to all of the inputs, so this function can be used to tabulate (alt,az)
-    coordinates on a user-specified grid covering sky x time x wavelength x
+    to all of the inputs, so this function can be used to tabulate an observing
+    model on a user-specified grid covering location x time x wavelength x
     temperature x pressure x humidity.
+
+    The model returned by this function can be passed to :func:`sky_to_altaz`
+    and :func:`altaz_to_sky` to transform sky coordinates such as RA,DEC to
+    and from this model's ALT,AZ coordinate frame(s).
 
     Parameters
     ----------
-    sky_coords : :class:`object`
-        An object representing one or more sky coordinates that are
-        transformable to an AltAz frame by invoking
-        ``sky_coords.transform_to()``. This argument will usually be an
-        instances of :class:`astropy.coordinates.SkyCoord`, but instances
-        of :class:`astropy.coordinates.AltAz` can also be used to isolate
-        the effects of changing the parameters of the atmospheric
-        refraction model.
     where : :class:`astropy.coordinates.EarthLocation`
-        The location where the observations take place.
+        The location(s) on the earth where the sky is being observed.
     when : :class:`astropy.time.Time`
         The time(s) of the observations.
     wavelength : :class:`astropy.units.Quantity`
@@ -253,9 +239,9 @@ def sky_to_altaz(sky_coords, where, when, wavelength, temperature=15*u.deg_C,
     Returns
     -------
     :class:`astropy.coordinates.AltAz`
-        An array of ALT-AZ coordinates with a shape given by
-        :func:`np.broadcast(sky_coords, when, wavelength, temperature, pressure)
-        <numpy.broadcast>`.
+        An array of ALT-AZ coordinate frames with a shape given by
+        :func:`np.broadcast(where, when, wavelength, temperature, pressure,
+        relative_humidity) <numpy.broadcast>`.
     """
     if not isinstance(relative_humidity, np.ndarray):
         relative_humidity = np.float(relative_humidity)
@@ -278,17 +264,135 @@ def sky_to_altaz(sky_coords, where, when, wavelength, temperature=15*u.deg_C,
 
     # Check that the input shapes are compatible for broadcasting to the output,
     # otherwise this will raise a ValueError.
-    output_shape = np.broadcast(sky_coords, when, wavelength,
-                                temperature, pressure).shape
+    np.broadcast(where, when, wavelength, temperature, pressure,
+                 relative_humidity)
 
     # Initialize the altaz frames for each (time, wavelength, temperature,
     # pressure, relative_humidity).
-    observing_frame = astropy.coordinates.AltAz(
+    return astropy.coordinates.AltAz(
         location=where, obstime=when, obswl=wavelength, temperature=T_in_C,
         pressure=pressure, relative_humidity=relative_humidity)
 
+
+def sky_to_altaz(sky_coords, observing_model):
+    """Convert sky coordinates to (alt,az) for specified observing conditions.
+
+    Transformations between sky coordinates such as RA,DEC and ALT,AZ involve
+    two steps.  First, define the atmosphere through which the sky is being
+    observed with a call to :func:`create_observing_model`.  Next, call this
+    function. For example, to locate Polaris from Kitt Peak, observing at
+    a wavelength of 5400 Angstroms:
+
+    >>> where = observatories['KPNO']
+    >>> when = astropy.time.Time('2001-01-01T00:00:00')
+    >>> obs_model = create_observing_model(where, when, 5400 * u.Angstrom)
+    >>> polaris = astropy.coordinates.ICRS(ra=37.95 * u.deg, dec=89.25 * u.deg)
+    >>> altaz = sky_to_altaz(polaris, obs_model)
+    >>> print('alt = %.3f deg, az = %.3f deg' %
+    ... (altaz.alt.to(u.deg).value, altaz.az.to(u.deg).value))
+    alt = 32.465 deg, az = 0.667 deg
+    >>> print('lat = %.3f deg' % where.latitude.to(u.deg).value)
+    lat = 31.963 deg
+
+    The output shape is determined by the usual `numpy broadcasting rules
+    <http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`__ applied
+    to the input coordinates and the refraction model.
+
+    Parameters
+    ----------
+    sky_coords : :class:`object`
+        An object representing one or more sky coordinates that are
+        transformable to an AltAz frame by invoking
+        ``sky_coords.transform_to()``. This argument will usually be an
+        instances of :class:`astropy.coordinates.SkyCoord`, but instances
+        of :class:`astropy.coordinates.AltAz` can also be used to isolate
+        the effects of changing the parameters of the atmospheric
+        refraction model.
+    observing_model : :class:`astropy.coordinates.AltAz`
+        The ALT-AZ coordinate frame(s) that specify the observing conditions,
+        normally obtained by calling :func:`create_observing_model`.
+
+    Returns
+    -------
+    :class:`astropy.coordinates.AltAz`
+        An array of ALT-AZ coordinates with a shape given by
+        :func:`np.broadcast(sky_coords, observing_model) <numpy.broadcast>`.
+    """
+    # Check that the input coordinates are compatible for broadcasting with
+    # the refraction model, otherwise this will raise a ValueError.
+    np.broadcast(sky_coords, observing_model)
+
     # Perform the transforms.
-    return sky_coords.transform_to(observing_frame)
+    return sky_coords.transform_to(observing_model)
+
+
+def altaz_to_sky(alt, az, observing_model, frame='icrs'):
+    """Convert (alt,az) to sky coordinates for specified observing conditions.
+
+    Transformations between sky coordinates such as RA,DEC and ALT,AZ involve
+    two steps.  First, define the atmosphere through which the sky is being
+    observed with a call to :func:`create_observing_model`.  Next, call this
+    function. For example, to map a North pointing at 60 degrees altitude from
+    Kitt Peak onto the sky, observing at a wavelength of 5400 Angstroms:
+
+    >>> where = observatories['KPNO']
+    >>> when = astropy.time.Time('2001-01-01T00:00:00')
+    >>> obs_model = create_observing_model(where, when, 5400 * u.Angstrom)
+    >>> radec = altaz_to_sky(60*u.deg, 0.*u.deg, obs_model)
+    >>> print('ra = %.3f deg, dec = %.3f deg' %
+    ... (radec.ra.to(u.deg).value, radec.dec.to(u.deg).value))
+    ra = 349.106 deg, dec = 61.962 deg
+
+    The output shape is determined by the usual `numpy broadcasting rules
+    <http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`__ applied
+    to the input coordinates and the refraction model.
+
+    Parameters
+    ----------
+    sky_coords : :class:`object`
+        An object representing one or more sky coordinates that are
+        transformable to an AltAz frame by invoking
+        ``sky_coords.transform_to()``. This argument will usually be an
+        instances of :class:`astropy.coordinates.SkyCoord`, but instances
+        of :class:`astropy.coordinates.AltAz` can also be used to isolate
+        the effects of changing the parameters of the atmospheric
+        refraction model.
+    observing_model : :class:`astropy.coordinates.AltAz`
+        The ALT-AZ coordinate frame(s) that specify the observing conditions,
+        normally obtained by calling :func:`create_observing_model`.
+    frame : str or :class:`astropy.coordinates.BaseCoordinateFrame` instance
+        The sky coordinate frame that the input alt-az observations should be
+        transformed to.  The default `'icrs'` corresponds to J2000 RA,DEC.
+        Some other useful frames are `'fk5'` and `'galactic'`.  See the
+        `astropy docs <http://astropy.readthedocs.org/
+        en/stable/coordinates/index.html#reference-api>`__ for details.
+
+    Returns
+    -------
+    :class:`astropy.coordinates.AltAz`
+        An array of ALT-AZ coordinates with a shape given by
+        :func:`np.broadcast(sky_coords, observing_model) <numpy.broadcast>`.
+    """
+    # Check that the input coordinates are compatible for broadcasting with
+    # the refraction model, otherwise this will raise a ValueError.
+    np.broadcast(alt, az, observing_model)
+
+    # Initialize the input coordinates.
+    altaz_coords = astropy.coordinates.AltAz(alt=alt, az=az,
+        location=observing_model.location, obstime=observing_model.obstime,
+        obswl=observing_model.obswl, temperature=observing_model.temperature,
+        pressure=observing_model.pressure,
+        relative_humidity=observing_model.relative_humidity)
+
+    # If the frame is specified as a string, try to convert it to
+    # a BaseCoordinateFrame instance.
+    if isinstance(frame, basestring):
+        if frame not in astropy.coordinates.frame_transform_graph.get_names():
+            raise ValueError('Invalid frame name: {0}.'.format(frame))
+        frame = astropy.coordinates.frame_transform_graph.lookup_name(frame)()
+
+    # Perform the transforms.
+    return altaz_coords.transform_to(frame)
 
 
 def adjust_time_to_hour_angle(nominal_time, target_ra, hour_angle,

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -6,8 +6,9 @@ The :func:`sky_to_altaz` and :func:`altaz_to_sky` functions use the
 atmospheric refraction model implemented in :class:`astropy.coordinates.AltAz`,
 based on that implemented in `ERFA <https://github.com/liberfa/erfa>`__, which
 is fast but becomes inaccurate at low altitudes (high airmass).  The table
-below gives the round-trip altitude errors for converting from (alt,az) to
-(ra,dec) and back to (alt,az):
+below (from `this notebook <https://github.com/desihub/specsim/
+blob/master/docs/nb/TransformExamples.ipynb>`__) gives the round-trip altitude
+errors for converting from (alt,az) to (ra,dec) and back to (alt,az):
 
 ============== ==============
 Altitude (deg) Error (arcsec)

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -31,6 +31,9 @@ observatories = {
 }
 
 
+low_altitude_threshold = 5 * u.deg
+
+
 def altaz_to_focalplane(alt, az, alt0, az0, platescale=1):
     """
     Convert local (alt,az) coordinates to focal plane (x,y) coordinates.
@@ -307,9 +310,8 @@ def sky_to_altaz(sky_coords, observing_model):
 
     Setting a pressure value of zero disables the atmospheric refraction model,
     so that returned coordinates are topocentric.  The atmospheric refraction
-    model becomes inaccurate for altitudes :attr:`below 5 degrees
-    <low_altitude_threshold>` so a `UserWarning` will be issued to flag this
-    condition.
+    model becomes inaccurate for altitudes below 5 degrees so a `UserWarning`
+    will be issued to flag this condition.
 
     Parameters
     ----------
@@ -364,9 +366,8 @@ def altaz_to_sky(alt, az, observing_model, frame='icrs'):
 
     Setting a pressure value of zero disables the atmospheric refraction model,
     so that returned coordinates are topocentric.  The atmospheric refraction
-    model becomes inaccurate for altitudes :attr:`below 5 degrees
-    <low_altitude_threshold>` so a `UserWarning` will be issued to flag this
-    condition.
+    model becomes inaccurate for altitudes below 5 degrees so a `UserWarning`
+    will be issued to flag this condition.
 
     The output shape is determined by the usual `numpy broadcasting rules
     <http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`__ applied
@@ -490,9 +491,6 @@ def adjust_time_to_hour_angle(nominal_time, target_ra, hour_angle,
         when = when - (lst - hour_angle) * u.hour / (15 * u.deg) * sidereal
 
     return when
-
-
-low_altitude_threshold = 5 * u.deg
 
 
 def _warn_for_low_altitudes(altaz):

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -2,6 +2,31 @@
 """
 Implement transformations between sky and focal plane coordinate systems.
 
+The :func:`sky_to_altaz` and :func:`altaz_to_sky` functions use the
+atmospheric refraction model implemented in :class:`astropy.coordinates.AltAz`,
+based on that implemented in `ERFA <https://github.com/liberfa/erfa>`__, which
+is fast but becomes inaccurate at low altitudes (high airmass).  The table
+below gives the round-trip altitude errors for converting from (alt,az) to
+(ra,dec) and back to (alt,az):
+
+============== ==============
+Altitude (deg) Error (arcsec)
+============== ==============
+          10.0        -15.175
+          15.0         -1.891
+          20.0         -0.425
+          25.0         -0.130
+          30.0         -0.048
+          35.0         -0.020
+          40.0         -0.009
+          45.0         -0.004
+============== ==============
+
+The :func:`sky_to_altaz` and :func:`altaz_to_sky` issue a warning when using
+altitude angles (and a non-zero atmospheric pressure) below 20 degrees.  The
+value of this threshold can be read and changed programmatically via the
+:attr:`low_altitude_threshold` module attribute.
+
 Attributes
 ----------
 observatories : dict
@@ -320,7 +345,7 @@ def sky_to_altaz(sky_coords, observing_model):
 
     Setting a pressure value of zero disables the atmospheric refraction model,
     so that returned coordinates are topocentric.  The atmospheric refraction
-    model becomes inaccurate for altitudes below 5 degrees so a `UserWarning`
+    model becomes inaccurate for altitudes below 20 degrees so a `UserWarning`
     will be issued to flag this condition.
 
     Parameters
@@ -381,7 +406,7 @@ def altaz_to_sky(alt, az, observing_model, frame='icrs'):
 
     Setting a pressure value of zero disables the atmospheric refraction model,
     so that returned coordinates are topocentric.  The atmospheric refraction
-    model becomes inaccurate for altitudes below 5 degrees so a `UserWarning`
+    model becomes inaccurate for altitudes below 20 degrees so a `UserWarning`
     will be issued to flag this condition.
 
     The output shape is determined by the usual `numpy broadcasting rules


### PR DESCRIPTION
Fixes #14.   The following round trip from ra,dec to alt,az and back again is now included in the unit tests:
```
    # Specify the observing conditions
    where = observatories['APO']
    when = Time(56383, format='mjd')
    wlen = 5400 * u.Angstrom
    temperature = 5 * u.deg_C
    pressure = 800 * u.kPa
    obs_model = create_observing_model(where=where, when=when,
        wavelength=wlen, temperature=temperature, pressure=pressure)

    # Perform the round trip.
    sky_in = SkyCoord(ra=0.5*u.rad, dec=1.5*u.rad, frame='icrs')
    altaz_out = sky_to_altaz(sky_in, obs_model)
    sky_out = altaz_to_sky(altaz_out.alt, altaz_out.az, obs_model, frame='icrs')

    # Check that we get back the initial coordinates.
    assert np.allclose(sky_in.ra, sky_out.ra)
    assert np.allclose(sky_in.dec, sky_out.dec)
```