### PR TITLE
Non null ivar

### DIFF
--- a/specsim/quick.py
+++ b/specsim/quick.py
@@ -446,10 +446,7 @@ class Quick(object):
             # nphot is a sum over orginal wave bins.
             # The effective calibration of convolved spectra is different from the true one
             # because resolution and transmission don't commute
-            smooth_camera_flux  = camera.sparseKernel.dot(self.sourceFlux)
-            smooth_camera_calib = np.zeros(smooth_camera_flux.shape)
-            fluxMask = smooth_camera_flux>0
-            smooth_camera_calib[fluxMask] =  camera.sourcePhotonsSmooth[fluxMask]/smooth_camera_flux[fluxMask]
+            smooth_camera_calib=camera.sparseKernel.dot(np.ones(self.sourceFlux.shape)*camera.sourceCalib)
             calib_downsampled = np.sum(smooth_camera_calib[:last].reshape(downShape),axis=1)
             # Add inverse variance for camera
             vcMask=(variance>0)&(calib_downsampled>0)

--- a/specsim/quick.py
+++ b/specsim/quick.py
@@ -446,7 +446,7 @@ class Quick(object):
             # nphot is a sum over orginal wave bins.
             # The effective calibration of convolved spectra is different from the true one
             # because resolution and transmission don't commute
-            smooth_camera_calib=camera.sparseKernel.dot(np.ones(self.sourceFlux.shape)*camera.sourceCalib)
+            smooth_camera_calib=camera.sparseKernel.dot(camera.sourceCalib)
             calib_downsampled = np.sum(smooth_camera_calib[:last].reshape(downShape),axis=1)
             # Add inverse variance for camera
             vcMask=(variance>0)&(calib_downsampled>0)


### PR DESCRIPTION
Yet another pull request on this (sorry for the git spam).
 - In the previous pull request , I used smoothcalib = smooth_flux/nphot that is only defined if nphot != 0 , so once again the code was returning null ivar for null input flux which is not good.
 - Now I do smoothcalib=kernel*calib. This corresponds to the previous calculation only for a flux=constant. The consequence is that the flux is not perfectly conserved any more for input spectra that differ from a constant. For instance, for a line at 5800A, we recover the input flux with a systematic bias of 0.0006.

I  suggest we use this new version even if we have to keep in mind that we do not expect a perfect flux conservation. Note that this bias is tiny and this feature also happens with real data where we are determining the calibration as 
```
effective_throughput 
= nphot / (kernel*star_model) 
= (kernel*(true_throughput*star_model)) / (kernel*star_model) 
!= true_throughput
``` 

