### PR TITLE
Improve handling of UT1-UTC for sidereal time calculations

### DIFF
--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -281,3 +281,9 @@ def test_adjust_missing_longitude():
     when = Time(56383, format='mjd', location=None)
     with pytest.raises(ValueError):
         adjusted = adjust_time_to_hour_angle(when, ra, 0.)
+
+
+def test_adjust_future():
+    ra = 45 * u.deg
+    when = Time(58000, format='mjd', location=observatories['APO'])
+    adjusted = adjust_time_to_hour_angle(when, ra, 0.)

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -280,10 +280,16 @@ def test_adjust_missing_longitude():
     ra = 45 * u.deg
     when = Time(56383, format='mjd', location=None)
     with pytest.raises(ValueError):
-        adjusted = adjust_time_to_hour_angle(when, ra, 0.)
+        adjusted = adjust_time_to_hour_angle(when, ra, 0. * u.deg)
 
 
 def test_adjust_future():
     ra = 45 * u.deg
     when = Time(58000, format='mjd', location=observatories['APO'])
-    adjusted = adjust_time_to_hour_angle(when, ra, 0.)
+    adjusted = adjust_time_to_hour_angle(when, ra, 0. * u.deg)
+
+
+def test_zero_hour_angle_adjust():
+    where = observatories['KPNO']
+    when = Time('2013-01-01 00:00:00', format='iso', location=where)
+    adjusted = adjust_time_to_hour_angle(when, 0 * u.deg, 0. * u.deg)

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -525,7 +525,9 @@ def adjust_time_to_hour_angle(nominal_time, target_ra, hour_angle,
         # Calculate the nominal local sidereal time of the target.
         try:
             lst = when.sidereal_time('apparent', longitude) - target_ra
-        except astropy.utils.iers.iers.IERSRangeError:
+        # Recent versions of astropy raise a subclass of IndexError
+        # astropy.utils.iers.iers.IERSRangeError
+        except IndexError:
             # Hardcode the mean UT1 - UTC offset for MJD in [54600, 57800]
             # in order to avoid issues with missing IERS tables.
             when.delta_ut1_utc = -0.1225

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -519,11 +519,17 @@ def adjust_time_to_hour_angle(nominal_time, target_ra, hour_angle,
         The desired accuracy could not be achieved after ``max_iterations``.
     """
     sidereal = 1 / 1.002737909350795
-    when = nominal_time
+    when = nominal_time.copy()
     num_iterations = 0
     while True:
         # Calculate the nominal local sidereal time of the target.
-        lst = when.sidereal_time('apparent', longitude) - target_ra
+        try:
+            lst = when.sidereal_time('apparent', longitude) - target_ra
+        except astropy.utils.iers.iers.IERSRangeError:
+            # Hardcode the mean UT1 - UTC offset for MJD in [54600, 57800]
+            # in order to avoid issues with missing IERS tables.
+            when.delta_ut1_utc = -0.1225
+            lst = when.sidereal_time('apparent', longitude) - target_ra
 
         # Are we close enough?
         if np.abs((lst - hour_angle).wrap_at('12 hours')) <= max_error:

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -545,7 +545,8 @@ def adjust_time_to_hour_angle(nominal_time, target_ra, hour_angle,
 
         # Offset to the nearest time with the desired hour angle.
         # Correct for the fact that 360 deg corresponds to a sidereal day.
-        when = when - (lst - hour_angle).wrap_at('12 hours') * u.hour / (15 * u.deg) * sidereal
+        when = (when - (lst - hour_angle).wrap_at('12 hours') * u.hour /
+                (15 * u.deg) * sidereal)
 
     return when
 


### PR DESCRIPTION
The astropy sidereal time calculation used by `transform.adjust_time_to_hour_angle` currently raises an exception when the time is not covered by the default IERS table of UT1-UTC values.  This PR is still in progress but already solves a blocking problem for calculating the eBOSS Margala corrections.  It might eventually also solve #26.