### PR TITLE
Simulation realism: part 1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@
 - Update readthedocs URLs (.org -> .io).
 - Implement optional radial and azimuthal plate scales varying with radius.
 - Add observation config parameters to support sky <-> xy transforms.
+- Refactor instrument module into separate instrument and camera modules.
 
 0.4 (2016-03-08)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 - Add testing against LTS release of astropy.
 - Drop testing against numpy 1.6 and add numpy 1.11.
 - Update readthedocs URLs (.org -> .io).
+- Implement optional radial and azimuthal plate scales varying with radius.
+- Add observation config parameters to support sky <-> xy transforms.
 
 0.4 (2016-03-08)
 ----------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,7 +34,7 @@ repeating the initialization step, for example::
     results1 = simulator.simulate()
 
     simulator.atmosphere.airmass = 1.5
-    simulator.instrument.exposure_time = 20 * u.min
+    simulator.observation.exposure_time = 20 * u.min
     simulator.source.update_out(filter_name='sdss2010-r', ab_magnitude_out=21.0)
     results2 = simulator.simulate()
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -54,6 +54,10 @@ repeating the initialization step, for example::
 .. automodapi:: specsim.source
     :no-inheritance-diagram:
 
+.. _observation-api:
+.. automodapi:: specsim.observation
+    :no-inheritance-diagram:
+
 .. _simulator-api:
 .. automodapi:: specsim.simulator
     :no-inheritance-diagram:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,6 +50,10 @@ repeating the initialization step, for example::
 .. automodapi:: specsim.instrument
     :no-inheritance-diagram:
 
+.. _camera-api:
+.. automodapi:: specsim.camera
+    :no-inheritance-diagram:
+
 .. _source-api:
 .. automodapi:: specsim.source
     :no-inheritance-diagram:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -167,12 +167,13 @@ configuration scheme:
 +-----------------------------+------------------------------------------------+
 | `ccd.*.gain`                | `instrument.cameras.*.constants.gain`          |
 +-----------------------------+------------------------------------------------+
-| `exptime`                   | `instrument.constants.exposure_time`           |
+| `exptime`                   | `observation.constants.exposure_time`          |
 +-----------------------------+------------------------------------------------+
 
 In addition to name mappings above, the specsim configuration values all have
 machine-readable units attached in a :ref:`constants section <config-constants>`
-(unlike the corresponding `desimodel` values, where units are specified in comments).
+(unlike the corresponding `desimodel` values, where units are specified in
+comments).
 
 Atmosphere
 ^^^^^^^^^^

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -155,7 +155,7 @@ configuration scheme:
 +=============================+================================================+
 | `area.M1_diameter`          | `instrument.constants.primary_mirror_diameter` |
 +-----------------------------+------------------------------------------------+
-| `fibers.diameter_arcsec`    | `instrument.constants.fiber_diameter`          |
+| `fibers.diameter_um`        | `instrument.constants.fiber_diameter`          |
 +-----------------------------+------------------------------------------------+
 | `area.obscuration_diameter` | `instrument.constants.obscuration_diameter`    |
 +-----------------------------+------------------------------------------------+

--- a/specsim/atmosphere.py
+++ b/specsim/atmosphere.py
@@ -344,11 +344,14 @@ class Moon(object):
 
     @airmass.setter
     def airmass(self, airmass):
-        self._airmass = airmass
+        # Remove any dimensionless astropy.units.Quantity wrapper since
+        # np.arcsin(Quantity(1)) has u.rad added automatically, but we
+        # add it explicitly below.
+        self._airmass = np.float(airmass)
         # Estimate the zenith angle corresponding to this observing airmass.
         # We invert eqn.3 of KS1991 for this (instead of eqn.14).
         self._obs_zenith = np.arcsin(
-            np.sqrt((1 - airmass ** -2) / 0.96)) * u.rad
+            np.sqrt((1 - self._airmass ** -2) / 0.96)) * u.rad
         self._update_required = True
 
 

--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -1,0 +1,360 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Model a fiber spectrograph camera for spectroscopic simulations.
+
+Cameras belong to an :class:`Instrument <specsim.instrument.Instrument>` and
+are usually initialized from a configuration used to create
+a simulator and then accessible via its ``instrument.cameras`` attribute,
+for example:
+
+    >>> import specsim.simulator
+    >>> simulator = specsim.simulator.Simulator('test')
+    >>> print(np.round(simulator.instrument.cameras[0].read_noise, 1))
+    2.9 electron / pix2
+
+See :doc:`/api` for examples of changing model parameters defined in the
+configuration. No attributes can be changed after a simulator has
+been created.  File a github issue if you would like to change this.
+"""
+from __future__ import print_function, division
+
+import numpy as np
+import scipy.sparse
+
+import astropy.units as u
+
+
+class Camera(object):
+    """Model the response of a single fiber spectrograph camera.
+
+    No camera attributes can be changed after an instrument has been
+    created.  File a github issue if you would like to change this.
+
+    Parameters
+    ----------
+    name : str
+        A brief descriptive name for this camera.  Typically a single letter
+        indicating the wavelength band covered by this camera.
+    wavelength : astropy.units.Quantity
+        Array of wavelength bin centers where the instrument response is
+        calculated, with units.  Must be equally spaced.
+    throughput : numpy.ndarray
+        Array of throughput values tabulated at each wavelength bin center.
+    row_size : astropy.units.Quantity
+        Array of row size values tabulated at each wavelength bin center.
+        Units are required, e.g. Angstrom / pixel.
+    fwhm_resolution : astropy.units.Quantity
+        Array of wavelength resolution FWHM values tabulated at each wavelength
+        bin center. Units are required, e.g., Angstrom.
+    neff_spatial : astropy.units.Quantity
+        Array of effective trace sizes in the spatial (fiber) direction
+        tabulated at each wavelength bin center.  Units are required, e.g.
+        pixel.
+    read_noise : astropy.units.Quantity
+        Camera noise per readout operation.  Units are required, e.g. electron.
+    dark_current : astropy.units.Quantity
+        Nominal mean dark current from sensor.  Units are required, e.g.
+        electron / hour.
+    gain : astropy.units.Quantity
+        CCD amplifier gain.  Units are required, e.g., electron / adu.
+        (This is really 1/gain).
+    num_sigmas_clip : float
+        Number of sigmas where the resolution should be clipped when building
+        a sparse resolution matrix.
+    output_pixel_size : astropy.units.Quantity
+        Size of output pixels for this camera.  Units are required, e.g.
+        Angstrom. Must be a multiple of the the spacing of the wavelength
+        input parameter.
+    """
+    def __init__(self, name, wavelength, throughput, row_size,
+                 fwhm_resolution, neff_spatial, read_noise, dark_current,
+                 gain, num_sigmas_clip, output_pixel_size):
+        self.name = name
+        self._wavelength = wavelength.to(self._wavelength_unit).value
+        self.throughput = throughput
+        self._row_size = row_size.to(self._wavelength_unit / u.pixel).value
+        self._fwhm_resolution = fwhm_resolution.to(self._wavelength_unit).value
+        self._neff_spatial = neff_spatial.to(u.pixel).value
+        self.read_noise = read_noise
+        self.dark_current = dark_current
+        self.gain = gain
+        self.num_sigmas_clip = num_sigmas_clip
+
+        # The arrays defining the CCD properties must all have identical
+        # wavelength coverage.
+        ccd_nonzero = np.where(self._row_size > 0)[0]
+        ccd_start, ccd_stop = ccd_nonzero[0], ccd_nonzero[-1] + 1
+        if (np.any(self._fwhm_resolution[:ccd_start] != 0) or
+            np.any(self._fwhm_resolution[ccd_stop:] != 0)):
+            raise RuntimeError('Resolution extends beyond CCD coverage.')
+        if (np.any(self._neff_spatial[:ccd_start] != 0) or
+            np.any(self._neff_spatial[ccd_stop:] != 0)):
+            raise RuntimeError('Spatial Neff extends beyond CCD coverage.')
+
+        # CCD properties must be valid across the coverage.
+        if np.any(self._row_size[ccd_start:ccd_stop] <= 0.):
+            raise RuntimeError('CCD row size has invalid values <= 0.')
+        if np.any(self._fwhm_resolution[ccd_start:ccd_stop] <= 0.):
+            raise RuntimeError('CCD resolution has invalid values <= 0.')
+        if np.any(self._neff_spatial[ccd_start:ccd_stop] <= 0.):
+            raise RuntimeError('CCD spatial Neff has invalid values <= 0.')
+
+        self.ccd_slice = slice(ccd_start, ccd_stop)
+        self.ccd_coverage = np.zeros_like(self._wavelength, dtype=bool)
+        self.ccd_coverage[ccd_start:ccd_stop] = True
+        self._wavelength_min = self._wavelength[ccd_start]
+        self._wavelength_max = self._wavelength[ccd_stop - 1]
+
+        # Calculate the size of each wavelength bin in units of pixel rows.
+        self._wavelength_bin_size = np.gradient(self._wavelength)
+        neff_wavelength = np.zeros_like(self._neff_spatial)
+        neff_wavelength[self.ccd_slice] = (
+            self._wavelength_bin_size[self.ccd_slice] /
+            self._row_size[self.ccd_slice])
+
+        # Calculate the effective pixel area contributing to the signal
+        # in each wavelength bin.
+        self.neff_pixels = neff_wavelength * self._neff_spatial * u.pixel ** 2
+
+        # Calculate the read noise per wavelength bin, assuming that
+        # readnoise is uncorrelated between pixels (hence the sqrt scaling). The
+        # value will be zero in pixels that are not used by this camera.
+        self.read_noise_per_bin = (
+            self.read_noise * np.sqrt(self.neff_pixels.value) * u.pixel ** 2
+            ).to(u.electron)
+
+        # Calculate the dark current per wavelength bin.
+        self.dark_current_per_bin = (
+            self.dark_current * self.neff_pixels).to(u.electron / u.s)
+
+        # Calculate the RMS resolution assuming a Gaussian PSF.
+        fwhm_to_sigma = 1. / (2 * np.sqrt(2 * np.log(2)))
+        self._rms_resolution = fwhm_to_sigma * self._fwhm_resolution
+
+        # Find the minimum wavelength that can disperse into the CCD,
+        # assuming a constant extrapolation of the resolution.
+        sigma_lo = self._rms_resolution[ccd_start]
+        min_wave = (self._wavelength[ccd_start] -
+                    self.num_sigmas_clip * sigma_lo)
+        if min_wave < self._wavelength[0]:
+            raise RuntimeError(
+                'Wavelength grid min does not cover {0}-camera response.'
+                .format(self.name))
+        matrix_start = np.where(self._wavelength >= min_wave)[0][0]
+
+        # Find the maximum wavelength that can disperse into the CCD,
+        # assuming a constant extrapolation of the resolution.
+        sigma_hi = self._rms_resolution[ccd_stop - 1]
+        max_wave = (self._wavelength[ccd_stop - 1] +
+                    self.num_sigmas_clip * sigma_hi)
+        if max_wave > self._wavelength[-1]:
+            raise RuntimeError(
+                'Wavelength grid max does not cover {0}-camera response.'
+                .format(self.name))
+        matrix_stop = np.where(self._wavelength <= max_wave)[0][-1] + 1
+        self.response_slice = slice(matrix_start, matrix_stop)
+
+        # Pad the RMS array to cover the full resolution matrix range.
+        sigma = np.empty((matrix_stop - matrix_start))
+        sigma[:ccd_start - matrix_start] = sigma_lo
+        sigma[ccd_start - matrix_start:ccd_stop - matrix_start] = (
+            self._rms_resolution[ccd_start:ccd_stop])
+        sigma[ccd_stop - matrix_start:] = sigma_hi
+
+        # Calculate the range of wavelengths where the dispersion will
+        # be evaluated.  The evaluation range extends beyond wavelengths that
+        # can disperse into the CCD in order to calculate the normalization.
+        wave = self._wavelength[matrix_start:matrix_stop]
+        min_wave = wave - self.num_sigmas_clip * sigma
+        max_wave = wave + self.num_sigmas_clip * sigma
+        eval_start = np.searchsorted(self._wavelength, min_wave)
+        eval_stop = np.searchsorted(self._wavelength, max_wave) + 1
+
+        # The columns of the resolution matrix are clipped to the CCD coverage.
+        column_start = np.maximum(eval_start, ccd_start)
+        column_stop = np.minimum(eval_stop, ccd_stop)
+        column_size = column_stop - column_start
+        assert np.all(column_size > 0)
+
+        # Prepare start, stop values for slicing eval -> column.
+        trim_start = column_start - eval_start
+        trim_stop = column_stop - eval_start
+        assert np.all(trim_stop > trim_start)
+
+        # Prepare a sparse resolution matrix in compressed column format.
+        matrix_size = np.sum(column_size)
+        data = np.empty((matrix_size,), float)
+        indices = np.empty((matrix_size,), int)
+        indptr = np.empty((len(column_size) + 1,), int)
+        indptr[0] = 0
+        indptr[1:] = np.cumsum(column_size)
+        assert indptr[-1] == matrix_size
+
+        # Fill sparse matrix arrays.
+        sparse_start = 0
+        for i in xrange(matrix_stop - matrix_start):
+            eval_slice = slice(eval_start[i], eval_stop[i])
+            w = self._wavelength[eval_slice]
+            dw = self._wavelength_bin_size[eval_slice]
+            column = dw * np.exp(-0.5 * ((w - wave[i]) / sigma[i]) ** 2)
+            # Normalize over the full evaluation range.
+            column /= np.sum(column)
+            # Trim to the CCD coverage.
+            s = slice(sparse_start, sparse_start + column_size[i])
+            data[s] = column[trim_start[i]:trim_stop[i]]
+            indices[s] = np.arange(column_start[i], column_stop[i]) - ccd_start
+            sparse_start = s.stop
+        assert np.all((indices >= 0) & (indices < ccd_stop - ccd_start))
+        assert s.stop == matrix_size
+
+        # Create the matrix in CSC format.
+        matrix_shape = (ccd_stop - ccd_start, matrix_stop - matrix_start)
+        self._resolution_matrix = scipy.sparse.csc_matrix(
+            (data, indices, indptr), shape=matrix_shape)
+        # Convert to CSR format for faster matrix multiplies.
+        self._resolution_matrix = self._resolution_matrix.tocsr()
+
+        # Initialize downsampled output pixels.
+        self._output_pixel_size = (
+            output_pixel_size.to(self._wavelength_unit).value)
+        # Check that we can downsample simulation pixels to obtain
+        # output pixels.  This check will only work if the simulation
+        # grid is equally spaced, but no other part of the Camera class
+        # class currently requires this.
+        wavelength_step = self._wavelength[1] - self._wavelength[0]
+        self._downsampling = int(round(
+            self._output_pixel_size / wavelength_step))
+        num_downsampled = int(
+            (self._wavelength_max - self._wavelength_min) //
+            self._output_pixel_size)
+        pixel_edges = (
+            self._wavelength_min - 0.5 * wavelength_step +
+            np.arange(num_downsampled + 1) * self._output_pixel_size)
+        sim_edges = (
+            self._wavelength[self.ccd_slice][::self._downsampling] -
+             0.5 * wavelength_step)
+        if not np.allclose(
+            pixel_edges, sim_edges, rtol=0., atol=1e-6 * wavelength_step):
+            raise ValueError(
+                'Cannot downsample {0}-camera pixels from {1:f} to {2} {3}.'
+                .format(self.name, wavelength_step, self._output_pixel_size,
+                        self._wavelength_unit))
+        # Save the centers of each output pixel.
+        self._output_wavelength = 0.5 * (pixel_edges[1:] + pixel_edges[:-1])
+        # Initialize the parameters used by the downsample() method.
+        self._output_slice = slice(
+            self.ccd_slice.start,
+            self.ccd_slice.start + num_downsampled * self._downsampling)
+        self._downsampled_shape = (num_downsampled, self._downsampling)
+
+
+    def get_output_resolution_matrix(self):
+        """Return the output resolution matrix.
+
+        The output resolution is calculated by summing output pixel
+        blocks of the full resolution matrix.  This is equivalent to
+        the convolution of our resolution with a boxcar representing
+        an output pixel.
+
+        This operation is relatively slow and requires a lot of memory
+        since the full resolution matrix is expanded to a dense array
+        during the calculation.
+
+        The result is returned as a dense matrix but will generally be
+        sparse, so can be converted to one of the scipy.sparse formats.
+        The result is not saved internally.
+
+        Edge effects are not handled very gracefully in order to return
+        a square matrix.
+
+        Returns
+        -------
+        numpy.ndarray
+            Square array of resolution matrix elements.
+        """
+        n = len(self._output_wavelength)
+        m = self._downsampling
+        i0 = self.ccd_slice.start - self.response_slice.start
+        return (self._resolution_matrix[: n * m, i0 : i0 + n * m].toarray()
+                .reshape(n, m, n, m).sum(axis=3).sum(axis=1) / float(m))
+
+
+    def downsample(self, data, method=np.sum):
+        """Downsample data tabulated on the simulation grid to output pixels.
+        """
+        data = np.asanyarray(data)
+        if data.shape != self._wavelength.shape:
+            raise ValueError(
+                'Invalid data shape for downsampling: {0}.'.format(data.shape))
+
+        return method(
+            data[self._output_slice].reshape(self._downsampled_shape), axis=-1)
+
+
+    def apply_resolution(self, flux):
+        """
+        Input should be on the simulation wavelength grid.
+
+        Any throughput should already be applied.
+        """
+        flux = np.asarray(flux)
+        dispersed = np.zeros_like(flux)
+
+        dispersed[self.ccd_slice] = self._resolution_matrix.dot(
+            flux[self.response_slice])
+
+        return dispersed
+
+
+    # Canonical wavelength unit used for all internal arrays.
+    _wavelength_unit = u.Angstrom
+
+
+    @property
+    def wavelength_min(self):
+        """Minimum wavelength covered by this camera's CCD.
+        """
+        return self._wavelength_min * self._wavelength_unit
+
+
+    @property
+    def wavelength_max(self):
+        """Maximum wavelength covered by this camera's CCD.
+        """
+        return self._wavelength_max * self._wavelength_unit
+
+
+    @property
+    def rms_resolution(self):
+        """Array of RMS resolution values.
+        """
+        return self._rms_resolution * self._wavelength_unit
+
+
+    @property
+    def row_size(self):
+        """Array of row sizes in the dispersion direction.
+        """
+        return self._row_size * self._wavelength_unit / u.pixel
+
+
+    @property
+    def neff_spatial(self):
+        """Array of effective pixel dimensions in the spatial (fiber) direction.
+        """
+        return self._neff_spatial * u.pixel
+
+
+    @property
+    def output_pixel_size(self):
+        """Size of output pixels.
+
+        Must be a multiple of the simulation wavelength grid.
+        """
+        return self._output_pixel_size * self._wavelength_unit
+
+
+    @property
+    def output_wavelength(self):
+        """Output pixel central wavelengths.
+        """
+        return self._output_wavelength * self._wavelength_unit

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -155,7 +155,7 @@ class Configuration(Node):
                 raise ValueError('Environment variable not set: {0}.'.format(e))
 
 
-    def get_sky_coordinate(self, parent):
+    def get_sky(self, parent):
         """Create a sky coordinate from a configuration node.
 
         Parameters
@@ -163,8 +163,13 @@ class Configuration(Node):
         parent : :class:`Node`
             Parent node in this configuration whose ``sky_coordinate`` child
             will be processed.
+
+        Returns
+        -------
+        astropy.coordinates.SkyCoord
+            Sky coordinates object constructed from node parameters.
         """
-        node = parent.sky_coordinate
+        node = parent.sky
         frame = getattr(node, 'frame', None)
         return astropy.coordinates.SkyCoord(node.coordinates, frame=frame)
 

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -38,6 +38,8 @@ import scipy.interpolate
 import astropy.units
 import astropy.table
 import astropy.utils.data
+import astropy.coordinates
+import astropy.time
 
 
 class Node(object):
@@ -161,7 +163,7 @@ class Configuration(Node):
         Parameters
         ----------
         parent : :class:`Node`
-            Parent node in this configuration whose ``sky_coordinate`` child
+            Parent node in this configuration whose ``sky`` child
             will be processed.
 
         Returns
@@ -172,6 +174,26 @@ class Configuration(Node):
         node = parent.sky
         frame = getattr(node, 'frame', None)
         return astropy.coordinates.SkyCoord(node.coordinates, frame=frame)
+
+
+    def get_timestamp(self, parent):
+        """Create a timestamp from a configuration node.
+
+        Parameters
+        ----------
+        parent : :class:`Node`
+            Parent node in this configuration whose ``timestamp`` child
+            will be processed.
+
+        Returns
+        -------
+        astropy.time.Time
+            Timestamp object constructed from node parameters.
+        """
+        node = parent.timestamp
+        format = getattr(node, 'format', None)
+        scale = getattr(node, 'scale', None)
+        return astropy.time.Time(node.when, format=format, scale=scale)
 
 
     def get_constants(self, parent, required_names=None):

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -155,6 +155,20 @@ class Configuration(Node):
                 raise ValueError('Environment variable not set: {0}.'.format(e))
 
 
+    def get_sky_coordinate(self, parent):
+        """Create a sky coordinate from a configuration node.
+
+        Parameters
+        ----------
+        parent : :class:`Node`
+            Parent node in this configuration whose ``sky_coordinate`` child
+            will be processed.
+        """
+        node = parent.sky_coordinate
+        frame = getattr(node, 'frame', None)
+        return astropy.coordinates.SkyCoord(node.coordinates, frame=frame)
+
+
     def get_constants(self, parent, required_names=None):
         """Interpret a constants node in this configuration.
 

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -230,12 +230,16 @@ class Configuration(Node):
         """
         constants = {}
         node = parent.constants
-        names = sorted(node.keys())
+        if node is None:
+            names = []
+        else:
+            names = sorted(node.keys())
         # All required names must be present, if specified.
         if required_names is not None:
             if not (set(required_names) <= set(names)):
                 raise RuntimeError(
-                    'Expected {0} for "{1}"'.format(required_names, node))
+                    'Expected {0} for "{1}.constants"'
+                    .format(required_names, parent))
             else:
                 extra_names = set(names) - set(required_names)
         else:
@@ -248,8 +252,8 @@ class Configuration(Node):
         if required_names is not None or optional_names is not None:
             if extra_names:
                 raise RuntimeError(
-                    'Unexpected "{0}" constants: {1}.'
-                    .format(node, extra_names))
+                    'Unexpected "{0}.constants" names: {1}.'
+                    .format(parent, extra_names))
         for name in names:
             value = getattr(node, name)
             unit = None

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -98,8 +98,8 @@ instrument:
         primary_mirror_diameter: 3.797 m
         obscuration_diameter: 1.8 m
         support_width: 0.025 m
-        # Averaged over the focal plane for 107.0 um physical diameter.
-        fiber_diameter: 1.52 arcsec
+        fiber_diameter: 107.0 um
+        plate_scale: 70.39473684210526 um / arcsec
     fiberloss:
         table:
             format: ascii

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -251,13 +251,13 @@ source:
     # Location of the source on the sky. A source will not be visible if
     # it lies out the observation field of view.
     location:
-        # Un-comment this constants block to hardcode the focal plane
-        # coordinates where this source is observed.  Otherwise, they
-        # are calculated from its sky position and the observing
-        # conditions.
-        #constants:
-        #    focal_x: 0 mm
-        #    focal_y: 0 mm
+        # If focal-plane (x,y) coordinates are specified, they will be
+        # calculated from the sky coordinates and observing conditions.
+        constants:
+            #focal_x: 0 mm
+            #focal_y: 100 mm
+        # Sky coordinates are optional (and ignored) when focal-plane (x,y)
+        # are specified.
         sky: {coordinates: 0h 0d, frame: icrs }
     # Set these parameters to apply a redshift transformation.
     z_in:

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -251,6 +251,13 @@ source:
     # Location of the source on the sky. A source will not be visible if
     # it lies out the observation field of view.
     location:
+        # Un-comment this constants block to hardcode the focal plane
+        # coordinates where this source is observed.  Otherwise, they
+        # are calculated from its sky position and the observing
+        # conditions.
+        #constants:
+        #    focal_x: 0 mm
+        #    focal_y: 0 mm
         sky: {coordinates: 0h 0d, frame: icrs }
     # Set these parameters to apply a redshift transformation.
     z_in:

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -94,7 +94,6 @@ instrument:
     name: DESI
     constants:
         # These values are copied from desimodel/data/desi.yaml
-        exposure_time: 1000.0 s
         primary_mirror_diameter: 3.797 m
         obscuration_diameter: 1.8 m
         support_width: 0.025 m
@@ -263,6 +262,8 @@ source:
 # The observation configuration is interpreted and validated by the
 # specsim.observation module.
 observation:
+    constants:
+        exposure_time: 1000.0 s
     pointing:
         sky:
             coordinates: 0h 0d

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -265,6 +265,16 @@ observation:
     observatory: KPNO
     constants:
         exposure_time: 1000.0 s
+        # Atmospheric pressure at the telescope (not at sea level) used
+        # to calculate atmospheric refraction.  Leave commented out to use a
+        # nominal value calculated for the observatory elevation.
+        # pressure: 79 kPa
+        # Air temperature at the telescope used to calculate atmospheric
+        # refraction (but only has a small effect).
+        temperature: 15 deg_C
+        # Relative humidity (0-1) at the telescope used to calculate atmospheric
+        # refraction (but only has a small effect).
+        relative_humidity: 0.
     exposure_start:
         timestamp:
             when: 57625

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -99,7 +99,14 @@ instrument:
         obscuration_diameter: 1.8 m
         support_width: 0.025 m
         fiber_diameter: 107.0 um
-        plate_scale: 70.39473684210526 um / arcsec
+    plate_scale:
+        table:
+            path: focalplane/platescale.txt
+            format: ascii
+            columns:
+                radius: { index: 0, unit: mm }
+                radial_scale: { index: 6, unit: um/arcsec }
+                azimuthal_scale: { index: 7, unit: um/arcsec }
     fiberloss:
         table:
             format: ascii

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -99,6 +99,7 @@ instrument:
         obscuration_diameter: 1.8 m
         support_width: 0.025 m
         fiber_diameter: 107.0 um
+        field_radius: 414.0 mm
     plate_scale:
         table:
             path: focalplane/platescale.txt

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -258,7 +258,7 @@ source:
             #focal_y: 100 mm
         # Sky coordinates are optional (and ignored) when focal-plane (x,y)
         # are specified.
-        sky: {coordinates: 0h 0d, frame: icrs }
+        sky: { coordinates: 0h 0d, frame: icrs }
     # Set these parameters to apply a redshift transformation.
     z_in:
     z_out:

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -254,3 +254,11 @@ source:
     # Set these parameters to normalize in a specified filter.
     filter_name:
     ab_magnitude_out:
+
+# The observation configuration is interpreted and validated by the
+# specsim.observation module.
+observation:
+    pointing:
+        sky_coordinate:
+            coordinates: 0h 0d
+            frame: icrs

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -248,6 +248,10 @@ source:
                 index: 1
                 # Note the factor of 1e-17 in the units!
                 unit: 1e-17 erg / (Angstrom cm2 s)
+    # Location of the source on the sky. A source will not be visible if
+    # it lies out the observation field of view.
+    location:
+        sky: {coordinates: 0h 0d, frame: icrs }
     # Set these parameters to apply a redshift transformation.
     z_in:
     z_out:
@@ -259,6 +263,6 @@ source:
 # specsim.observation module.
 observation:
     pointing:
-        sky_coordinate:
+        sky:
             coordinates: 0h 0d
             frame: icrs

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -268,7 +268,7 @@ observation:
         # Atmospheric pressure at the telescope (not at sea level) used
         # to calculate atmospheric refraction.  Leave commented out to use a
         # nominal value calculated for the observatory elevation.
-        # pressure: 79 kPa
+        #pressure: 79 kPa
         # Air temperature at the telescope used to calculate atmospheric
         # refraction (but only has a small effect).
         temperature: 15 deg_C
@@ -277,8 +277,11 @@ observation:
         relative_humidity: 0.
     exposure_start:
         timestamp:
-            when: 57625
+            when: 55000.5
             format: mjd
+        # This optional parameter adjusts the timestamp by +/-12h to
+        # achieve the specified hour angle for the boresight (ra, dec).
+        #adjust_to_hour_angle: -0.5h
     pointing:
         sky:
             coordinates: 0h 0d

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -262,8 +262,13 @@ source:
 # The observation configuration is interpreted and validated by the
 # specsim.observation module.
 observation:
+    observatory: KPNO
     constants:
         exposure_time: 1000.0 s
+    exposure_start:
+        timestamp:
+            when: 57625
+            format: mjd
     pointing:
         sky:
             coordinates: 0h 0d

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -129,7 +129,7 @@ source:
             focal_y: 100mm
         # Sky coordinates are optional (and ignored) when focal-plane (x,y)
         # are specified.
-        sky: {coordinates: 0h 0d, frame: icrs }
+        sky: { coordinates: 0h 0d, frame: icrs }
     # Set these parameters to apply a redshift transformation.
     z_in:
     z_out:

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -65,7 +65,6 @@ atmosphere:
 instrument:
     name: Test Instrument
     constants:
-        exposure_time: 1000.0 s
         primary_mirror_diameter: 3.797 m
         obscuration_diameter: 1.8 m
         support_width: 0.025 m
@@ -134,6 +133,8 @@ source:
 # The observation configuration is interpreted and validated by the
 # specsim.observation module.
 observation:
+    constants:
+        exposure_time: 1000.0 s
     pointing:
         sky:
             coordinates: 0h 0d

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -136,6 +136,16 @@ observation:
     observatory: APO
     constants:
         exposure_time: 1000.0 s
+        # Atmospheric pressure at the telescope (not at sea level) used
+        # to calculate atmospheric refraction.  Leave commented out to use a
+        # nominal value calculated for the observatory elevation.
+        pressure: 79 kPa
+        # Air temperature at the telescope used to calculate atmospheric
+        # refraction (but only has a small effect).
+        temperature: 15 deg_C
+        # Relative humidity (0-1) at the telescope used to calculate atmospheric
+        # refraction (but only has a small effect).
+        relative_humidity: 0.
     exposure_start:
         timestamp:
             when: 57625

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -133,8 +133,13 @@ source:
 # The observation configuration is interpreted and validated by the
 # specsim.observation module.
 observation:
+    observatory: APO
     constants:
         exposure_time: 1000.0 s
+    exposure_start:
+        timestamp:
+            when: 57625
+            format: mjd
     pointing:
         sky:
             coordinates: 0h 0d

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -70,6 +70,7 @@ instrument:
         obscuration_diameter: 1.8 m
         support_width: 0.025 m
         fiber_diameter: 107.0 um
+        field_radius: 414.0 mm
     plate_scale:
         constants:
             value: 70.4 um / arcsec

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -119,6 +119,10 @@ source:
         columns:
             wavelength: { name: wavelength }
             flux: { name: flux }
+    # Location of the source on the sky. A source will not be visible if
+    # it lies out the observation field of view.
+    location:
+        sky: {coordinates: 0h 0d, frame: icrs }
     # Set these parameters to apply a redshift transformation.
     z_in:
     z_out:
@@ -130,6 +134,6 @@ source:
 # specsim.observation module.
 observation:
     pointing:
-        sky_coordinate:
+        sky:
             coordinates: 0h 0d
             frame: icrs

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -148,8 +148,11 @@ observation:
         relative_humidity: 0.
     exposure_start:
         timestamp:
-            when: 57625
+            when: 55000.5
             format: mjd
+        # This optional parameter adjusts the timestamp by +/-12h to
+        # achieve the specified hour angle for the boresight (ra, dec).
+        adjust_to_hour_angle: -0.5h
     pointing:
         sky:
             coordinates: 0h 0d

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -70,7 +70,9 @@ instrument:
         obscuration_diameter: 1.8 m
         support_width: 0.025 m
         fiber_diameter: 107.0 um
-        plate_scale: 70.39473684210526 um / arcsec
+    plate_scale:
+        constants:
+            value: 70.39473684210526 um / arcsec
     fiberloss:
         table:
             format: ascii

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -125,3 +125,11 @@ source:
     # Set these parameters to normalize in a specified filter.
     filter_name:
     ab_magnitude_out:
+
+# The observation configuration is interpreted and validated by the
+# specsim.observation module.
+observation:
+    pointing:
+        sky_coordinate:
+            coordinates: 0h 0d
+            frame: icrs

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -125,8 +125,8 @@ source:
         # If focal-plane (x,y) coordinates are left blank, they will be
         # calculated from the sky coordinates and observing conditions.
         constants:
-            focal_x: 0 mm
-            focal_y: 100 mm
+            focal_x: 0mm
+            focal_y: 100mm
         # Sky coordinates are optional (and ignored) when focal-plane (x,y)
         # are specified.
         sky: {coordinates: 0h 0d, frame: icrs }

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -69,8 +69,8 @@ instrument:
         primary_mirror_diameter: 3.797 m
         obscuration_diameter: 1.8 m
         support_width: 0.025 m
-        # Averaged over the focal plane for 107.0 um physical diameter.
-        fiber_diameter: 1.52 arcsec
+        fiber_diameter: 107.0 um
+        plate_scale: 70.39473684210526 um / arcsec
     fiberloss:
         table:
             format: ascii

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -72,7 +72,7 @@ instrument:
         fiber_diameter: 107.0 um
     plate_scale:
         constants:
-            value: 70.39473684210526 um / arcsec
+            value: 70.4 um / arcsec
     fiberloss:
         table:
             format: ascii

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -122,9 +122,13 @@ source:
     # Location of the source on the sky. A source will not be visible if
     # it lies out the observation field of view.
     location:
+        # If focal-plane (x,y) coordinates are left blank, they will be
+        # calculated from the sky coordinates and observing conditions.
         constants:
             focal_x: 0 mm
             focal_y: 100 mm
+        # Sky coordinates are optional (and ignored) when focal-plane (x,y)
+        # are specified.
         sky: {coordinates: 0h 0d, frame: icrs }
     # Set these parameters to apply a redshift transformation.
     z_in:

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -122,6 +122,9 @@ source:
     # Location of the source on the sky. A source will not be visible if
     # it lies out the observation field of view.
     location:
+        constants:
+            focal_x: 0 mm
+            focal_y: 100 mm
         sky: {coordinates: 0h 0d, frame: icrs }
     # Set these parameters to apply a redshift transformation.
     z_in:

--- a/specsim/driver.py
+++ b/specsim/driver.py
@@ -27,8 +27,8 @@ def main(args=None):
         help='provide verbose output on progress')
     parser.add_argument('-c', '--config', default='test',
         help='name of the simulation configuration to use')
-    parser.add_argument('--exposure-time', type=float, default=1000.,
-        help='exposure time in seconds to use.')
+    parser.add_argument('--exposure-time', type=str, default='1000s',
+        help='exposure time in to use (with units)')
     parser.add_argument('--sky-condition', type=str, default=None,
         help='sky condition to use (uses default if not set)')
     parser.add_argument('--airmass', type=float, default=1.,
@@ -83,8 +83,7 @@ def main(args=None):
         if args.moon_separation is not None:
             moon.separation_angle = args.moon_separation * u.deg
 
-    config.observation.constants.exposure_time = (
-        '{0} s'.format(args.exposure_time))
+    config.observation.constants.exposure_time = args.exposure_time
 
     if args.model is not None:
         config.source.type = args.model

--- a/specsim/driver.py
+++ b/specsim/driver.py
@@ -79,7 +79,7 @@ def main(args=None):
         if args.moon_separation is not None:
             moon.separation_angle = args.moon_separation * u.deg
 
-    config.instrument.constants.exposure_time = (
+    config.observation.constants.exposure_time = (
         '{0} s'.format(args.exposure_time))
 
     if args.model is not None:

--- a/specsim/driver.py
+++ b/specsim/driver.py
@@ -92,20 +92,24 @@ def main(args=None):
     config.source.filter_name = args.filter
     config.source.ab_magnitude_out = args.ab_mag
 
-    if args.focal_x is not None:
-        if args.focal_y is None:
-            print('Must set both focal-x and focal-y.')
-            return -1
-        else:
-            config.source.location.constants.focal_x = args.focal_x
-            config.source.location.constants.focal_y = args.focal_y
-
     # Initialize the simulator.
     try:
         simulator = specsim.simulator.Simulator(config)
     except RuntimeError as e:
         print(e)
         return -1
+
+    # Set parameters after configuration.
+    simulator.observation.exposure_time = specsim.config.parse_quantity(
+        args.exposure_time)
+    if args.focal_x is not None:
+        if args.focal_y is None:
+            print('Must set both focal-x and focal-y.')
+            return -1
+        else:
+            focal_x = specsim.config.parse_quantity(args.focal_x)
+            focal_y = specsim.config.parse_quantity(args.focal_y)
+            simulator.source.focal_xy = focal_x, focal_y
 
     # Perform the simulation.
     simulator.simulate()

--- a/specsim/driver.py
+++ b/specsim/driver.py
@@ -83,8 +83,6 @@ def main(args=None):
         if args.moon_separation is not None:
             moon.separation_angle = args.moon_separation * u.deg
 
-    config.observation.constants.exposure_time = args.exposure_time
-
     if args.model is not None:
         config.source.type = args.model
     config.source.z_in = args.z_in
@@ -100,16 +98,20 @@ def main(args=None):
         return -1
 
     # Set parameters after configuration.
-    simulator.observation.exposure_time = specsim.config.parse_quantity(
-        args.exposure_time)
-    if args.focal_x is not None:
-        if args.focal_y is None:
-            print('Must set both focal-x and focal-y.')
-            return -1
-        else:
-            focal_x = specsim.config.parse_quantity(args.focal_x)
-            focal_y = specsim.config.parse_quantity(args.focal_y)
-            simulator.source.focal_xy = focal_x, focal_y
+    try:
+        simulator.observation.exposure_time = specsim.config.parse_quantity(
+            args.exposure_time, u.s)
+        if args.focal_x is not None:
+            if args.focal_y is None:
+                print('Must set both focal-x and focal-y.')
+                return -1
+            else:
+                focal_x = specsim.config.parse_quantity(args.focal_x, u.mm)
+                focal_y = specsim.config.parse_quantity(args.focal_y, u.mm)
+                simulator.source.focal_xy = focal_x, focal_y
+    except ValueError as e:
+        print(e)
+        return -1
 
     # Perform the simulation.
     simulator.simulate()

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -6,16 +6,14 @@ a simulator and then accessible via its ``instrument`` attribute, for example:
 
     >>> import specsim.simulator
     >>> simulator = specsim.simulator.Simulator('test')
-    >>> print(np.round(simulator.instrument.exposure_time, 1))
-    1000.0 s
-    >>> simulator.atmosphere.airmass
-    1.0
+    >>> print(np.round(simulator.instrument.fiber_diameter, 1))
+    107.0 um
+    >>> print(np.round(simulator.instrument.cameras[0].read_noise, 1))
+    2.9 electron / pix2
 
 See :doc:`/api` for examples of changing model parameters defined in the
-configuration.  Certain parameters can also be changed after a model has
-been initialized, for example:
-
-    >>> simulator.instrument.exposure_time = 1200 * u.s
+configuration. No attributes can be changed after a simulator has
+been created.  File a github issue if you would like to change this.
 
 See :class:`Instrument` and :class:`Camera` for details.
 """
@@ -37,9 +35,8 @@ class Instrument(object):
     A spectrograph can have multiple cameras with different wavelength
     coverage.
 
-    The only attribute that can be changed after an instrument has been
-    created is :attr:`exposure_time`.  File a github issue if you would like
-    to expand this list.
+    No instrument attributes can be changed after an instrument has been
+    created. File a github issue if you would like to change this.
 
     Parameters
     ----------
@@ -67,8 +64,6 @@ class Instrument(object):
         Maximum radius of the field of view in length units measured at
         the focal plane. Converted to an angular field of view using the
         plate scale.
-    exposure_time : astropy.units.Quantity
-        Exposure time used to scale the instrument response, with units.
     radial_scale : callable
         Callable function that returns the plate scale in the radial
         (meridional) direction (with appropriate units) as a function of
@@ -80,7 +75,7 @@ class Instrument(object):
     """
     def __init__(self, name, wavelength, fiber_acceptance_dict, cameras,
                  primary_mirror_diameter, obscuration_diameter, support_width,
-                 fiber_diameter, field_radius, exposure_time, radial_scale, azimuthal_scale):
+                 fiber_diameter, field_radius, radial_scale, azimuthal_scale):
         self.name = name
         self._wavelength = wavelength
         self.fiber_acceptance_dict = fiber_acceptance_dict
@@ -90,7 +85,6 @@ class Instrument(object):
         self.support_width = support_width
         self.fiber_diameter = fiber_diameter
         self.field_radius = field_radius
-        self.exposure_time = exposure_time
         self.radial_scale = radial_scale
         self.azimuthal_scale = azimuthal_scale
 
@@ -172,7 +166,6 @@ class Instrument(object):
             Constant source flux to use for displaying the instrument response.
         exposure_time : astropy.units.Quantity or None
             Exposure time to use for displaying the instrument response.
-            Use the configured exposure time when this parameter is None.
         cmap : str or matplotlib.colors.Colormap
             Matplotlib colormap name or instance to use for displaying the
             instrument response.  Colors are selected for each camera
@@ -190,9 +183,6 @@ class Instrument(object):
         wave = self._wavelength.value
         wave_unit = self._wavelength.unit
         dwave = np.gradient(wave)
-
-        if exposure_time is None:
-            exposure_time = self.exposure_time
 
         for source_type in self.source_types:
             # Plot fiber acceptance fractions without labels.
@@ -630,7 +620,7 @@ def initialize(config):
 
     constants = config.get_constants(
         config.instrument,
-        ['exposure_time', 'primary_mirror_diameter', 'obscuration_diameter',
+        ['primary_mirror_diameter', 'obscuration_diameter',
          'support_width', 'fiber_diameter', 'field_radius'])
 
     try:
@@ -668,8 +658,7 @@ def initialize(config):
         name, config.wavelength, fiber_acceptance_dict, initialized_cameras,
         constants['primary_mirror_diameter'], constants['obscuration_diameter'],
         constants['support_width'], constants['fiber_diameter'],
-        constants['field_radius'],
-        constants['exposure_time'], radial_scale, azimuthal_scale)
+        constants['field_radius'], radial_scale, azimuthal_scale)
 
     if config.verbose:
         # Print some derived quantities.

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -63,6 +63,10 @@ class Instrument(object):
     fiber_diameter : astropy.units.Quantity
         Physical diameter of the simulated fibers, with units of length.
         Converted to an on-sky diameter using the plate scale.
+    field_radius : astropy.units.Quantity
+        Maximum radius of the field of view in length units measured at
+        the focal plane. Converted to an angular field of view using the
+        plate scale.
     exposure_time : astropy.units.Quantity
         Exposure time used to scale the instrument response, with units.
     radial_scale : callable
@@ -76,7 +80,7 @@ class Instrument(object):
     """
     def __init__(self, name, wavelength, fiber_acceptance_dict, cameras,
                  primary_mirror_diameter, obscuration_diameter, support_width,
-                 fiber_diameter, exposure_time, radial_scale, azimuthal_scale):
+                 fiber_diameter, field_radius, exposure_time, radial_scale, azimuthal_scale):
         self.name = name
         self._wavelength = wavelength
         self.fiber_acceptance_dict = fiber_acceptance_dict
@@ -85,6 +89,7 @@ class Instrument(object):
         self.obscuration_diameter = obscuration_diameter
         self.support_width = support_width
         self.fiber_diameter = fiber_diameter
+        self.field_radius = field_radius
         self.exposure_time = exposure_time
         self.radial_scale = radial_scale
         self.azimuthal_scale = azimuthal_scale
@@ -626,7 +631,7 @@ def initialize(config):
     constants = config.get_constants(
         config.instrument,
         ['exposure_time', 'primary_mirror_diameter', 'obscuration_diameter',
-         'support_width', 'fiber_diameter'])
+         'support_width', 'fiber_diameter', 'field_radius'])
 
     try:
         # Try to read a tabulated plate scale first.
@@ -663,6 +668,7 @@ def initialize(config):
         name, config.wavelength, fiber_acceptance_dict, initialized_cameras,
         constants['primary_mirror_diameter'], constants['obscuration_diameter'],
         constants['support_width'], constants['fiber_diameter'],
+        constants['field_radius'],
         constants['exposure_time'], radial_scale, azimuthal_scale)
 
     if config.verbose:

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -257,7 +257,8 @@ class Instrument(object):
         # Calculate the dimensionless fiber area ratio.
         fiber_area_ratio = (fiber_area / mean_fiber_area).si.value
 
-        # Calculate the dimensionless ratio of azimuthal / radial scales.
+        # Calculate the dimensionless ratio of azimuthal / radial plate scales
+        # which is the ratio of the on-sky radial / azimuthal extends.
         shape_ratio = (self.azimuthal_scale(radius) /
                        self.radial_scale(radius)).si.value
 
@@ -277,8 +278,8 @@ class Instrument(object):
 
         ax2.plot(angle, fiber_area_ratio, 'b', lw=2, label='Area ratio')
         ax2.plot(angle, shape_ratio, 'k', lw=2, ls='--',
-                 label='Azimuthal/radial scales')
-        ax2.set_ylabel('Fiber area and shape ratios', fontsize='large')
+                 label='Radial/azimuthal')
+        ax2.set_ylabel('Fiber sky area and shape ratios', fontsize='large')
         ax2.grid()
         ax2.legend(loc='upper right')
 
@@ -289,6 +290,8 @@ class Instrument(object):
                      verticalalignment='bottom', fontsize='large')
 
         ax2.set_xlabel('Field angle [deg]', fontsize='large')
+        plt.subplots_adjust(
+            left=0.10, right=0.98, bottom=0.07, top=0.97, hspace=0.05)
 
 
     def get_fiber_acceptance(self, source):

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -155,7 +155,7 @@ class Instrument(object):
 
 
     def plot(self, flux=1e-17 * u.erg / (u.cm**2 * u.s * u.Angstrom),
-             exposure_time=None, cmap='nipy_spectral'):
+             exposure_time=1000 * u.s, cmap='nipy_spectral'):
         """Plot a summary of this instrument's model.
 
         Requires that the matplotlib package is installed.
@@ -164,7 +164,7 @@ class Instrument(object):
         ----------
         flux : astropy.units.Quantity
             Constant source flux to use for displaying the instrument response.
-        exposure_time : astropy.units.Quantity or None
+        exposure_time : astropy.units.Quantity
             Exposure time to use for displaying the instrument response.
         cmap : str or matplotlib.colors.Colormap
             Matplotlib colormap name or instance to use for displaying the

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -189,7 +189,7 @@ class Instrument(object):
             radius.to(self._radius_unit)) * self._angle_unit
 
 
-    def field_angle_to_radius(self, radius):
+    def field_angle_to_radius(self, angle):
         """Convert focal plane radius to an angle relative to the boresight.
 
         The mapping :math:`r(\\theta)` is calculated by numerically inverting
@@ -215,8 +215,8 @@ class Instrument(object):
         ValueError
             One or more input values are outside the allowed range.
         """
-        return self._radius_to_angle(
-            radius.to(self._radius_unit)) * self._angle_unit
+        return self._angle_to_radius(
+            angle.to(self._angle_unit)) * self._radius_unit
 
 
     def plot_field_distortion(self):

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -98,15 +98,6 @@ class Instrument(object):
         self.effective_area = (
             math.pi * ((0.5 * D) ** 2 - (0.5 * obs) ** 2) - 4 * support_area)
 
-        # Calculate the fiber area on the sky assuming the fiber is
-        # positioned at the center of the focal plane.
-        focal_plane_r = 0 * u.mm
-        radial_size = (
-            0.5 * self.fiber_diameter / self.radial_scale(focal_plane_r))
-        azimuthal_size = (
-            0.5 * self.fiber_diameter / self.azimuthal_scale(focal_plane_r))
-        self.fiber_area = np.pi * radial_size * azimuthal_size
-
         # Tabulate the mapping between focal plane radius and boresight
         # opening angle by integrating the radial plate scale.
         # Use mm and radians as the canonical units.
@@ -826,8 +817,6 @@ def initialize(config):
         # Print some derived quantities.
         print('Telescope effective area: {0:.3f}'
               .format(instrument.effective_area))
-        print('Fiber entrance area: {0:.3f}'
-              .format(instrument.fiber_area))
         print('Field of view diameter: {0:.1f} = {1:.2f}.'
               .format(2 * instrument.field_radius.to(u.mm),
                       2 * instrument.field_angle.to(u.deg)))

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -158,6 +158,13 @@ class Instrument(object):
     def field_radius_to_angle(self, radius):
         """Convert focal plane radius to an angle relative to the boresight.
 
+        The mapping is derived from the radial (meridional) plate scale
+        function :math:`dr/d\\theta(r)` via the integral:
+
+        .. math::
+
+            \\theta(r) = \int_0^{r} \\frac{dr}{dr/d\\theta(r')}\, dr'
+
         The input values must be within the field of view.
         Use :meth:`field_angle_to_radius` for the inverse transform.
 
@@ -184,6 +191,9 @@ class Instrument(object):
 
     def field_angle_to_radius(self, radius):
         """Convert focal plane radius to an angle relative to the boresight.
+
+        The mapping :math:`r(\\theta)` is calculated by numerically inverting
+        the function :math:`\\theta(r)`.
 
         The input values must be within the field of view.
         Use :meth:`field_radius_to_angle` for the inverse transform.

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -8,33 +8,31 @@ a simulator and then accessible via its ``instrument`` attribute, for example:
     >>> simulator = specsim.simulator.Simulator('test')
     >>> print(np.round(simulator.instrument.fiber_diameter, 1))
     107.0 um
-    >>> print(np.round(simulator.instrument.cameras[0].read_noise, 1))
-    2.9 electron / pix2
 
 See :doc:`/api` for examples of changing model parameters defined in the
 configuration. No attributes can be changed after a simulator has
 been created.  File a github issue if you would like to change this.
 
-See :class:`Instrument` and :class:`Camera` for details.
+An :class:`Instrument` includes one or more
+:class:`Cameras <specsim.camera.Camera>`.
 """
 from __future__ import print_function, division
 
-import math
-
 import numpy as np
-import scipy.sparse
 import scipy.interpolate
 import scipy.integrate
 
 import astropy.constants
 import astropy.units as u
 
+import specsim.camera
+
 
 class Instrument(object):
     """Model the instrument response of a fiber spectrograph.
 
-    A spectrograph can have multiple cameras with different wavelength
-    coverage.
+    A spectrograph can have multiple :mod:`cameras <specsim.camera>` with
+    different wavelength coverages.
 
     No instrument attributes can be changed after an instrument has been
     created. File a github issue if you would like to change this.
@@ -50,8 +48,8 @@ class Instrument(object):
         Dictionary of fiber acceptance fractions tabulated for different
         source models, with keys corresponding to source model names.
     cameras : list
-        List of :class:`Camera` instances representing the camera(s) of
-        this instrument.
+        List of :class:`specsim.camera.Camera` instances representing the
+        camera(s) of this instrument.
     primary_mirror_diameter : astropy.units.Quantity
         Diameter of the primary mirror, with units.
     obscuration_diameter : astropy.units.Quantity
@@ -96,7 +94,7 @@ class Instrument(object):
         obs = self.obscuration_diameter
         support_area = 0.5*(D - obs) * self.support_width
         self.effective_area = (
-            math.pi * ((0.5 * D) ** 2 - (0.5 * obs) ** 2) - 4 * support_area)
+            np.pi * ((0.5 * D) ** 2 - (0.5 * obs) ** 2) - 4 * support_area)
 
         # Tabulate the mapping between focal plane radius and boresight
         # opening angle by integrating the radial plate scale.
@@ -401,345 +399,11 @@ class Instrument(object):
         ax2.set_xlim(wave[0], wave[-1])
 
 
-class Camera(object):
-    """Model the response of a single fiber spectrograph camera.
-
-    No camera attributes can be changed after an instrument has been
-    created.  File a github issue if you would like to change this.
-
-    Parameters
-    ----------
-    name : str
-        A brief descriptive name for this camera.  Typically a single letter
-        indicating the wavelength band covered by this camera.
-    wavelength : astropy.units.Quantity
-        Array of wavelength bin centers where the instrument response is
-        calculated, with units.  Must be equally spaced.
-    throughput : numpy.ndarray
-        Array of throughput values tabulated at each wavelength bin center.
-    row_size : astropy.units.Quantity
-        Array of row size values tabulated at each wavelength bin center.
-        Units are required, e.g. Angstrom / pixel.
-    fwhm_resolution : astropy.units.Quantity
-        Array of wavelength resolution FWHM values tabulated at each wavelength
-        bin center. Units are required, e.g., Angstrom.
-    neff_spatial : astropy.units.Quantity
-        Array of effective trace sizes in the spatial (fiber) direction
-        tabulated at each wavelength bin center.  Units are required, e.g.
-        pixel.
-    read_noise : astropy.units.Quantity
-        Camera noise per readout operation.  Units are required, e.g. electron.
-    dark_current : astropy.units.Quantity
-        Nominal mean dark current from sensor.  Units are required, e.g.
-        electron / hour.
-    gain : astropy.units.Quantity
-        CCD amplifier gain.  Units are required, e.g., electron / adu.
-        (This is really 1/gain).
-    num_sigmas_clip : float
-        Number of sigmas where the resolution should be clipped when building
-        a sparse resolution matrix.
-    output_pixel_size : astropy.units.Quantity
-        Size of output pixels for this camera.  Units are required, e.g.
-        Angstrom. Must be a multiple of the the spacing of the wavelength
-        input parameter.
-    """
-    def __init__(self, name, wavelength, throughput, row_size,
-                 fwhm_resolution, neff_spatial, read_noise, dark_current,
-                 gain, num_sigmas_clip, output_pixel_size):
-        self.name = name
-        self._wavelength = wavelength.to(self._wavelength_unit).value
-        self.throughput = throughput
-        self._row_size = row_size.to(self._wavelength_unit / u.pixel).value
-        self._fwhm_resolution = fwhm_resolution.to(self._wavelength_unit).value
-        self._neff_spatial = neff_spatial.to(u.pixel).value
-        self.read_noise = read_noise
-        self.dark_current = dark_current
-        self.gain = gain
-        self.num_sigmas_clip = num_sigmas_clip
-
-        # The arrays defining the CCD properties must all have identical
-        # wavelength coverage.
-        ccd_nonzero = np.where(self._row_size > 0)[0]
-        ccd_start, ccd_stop = ccd_nonzero[0], ccd_nonzero[-1] + 1
-        if (np.any(self._fwhm_resolution[:ccd_start] != 0) or
-            np.any(self._fwhm_resolution[ccd_stop:] != 0)):
-            raise RuntimeError('Resolution extends beyond CCD coverage.')
-        if (np.any(self._neff_spatial[:ccd_start] != 0) or
-            np.any(self._neff_spatial[ccd_stop:] != 0)):
-            raise RuntimeError('Spatial Neff extends beyond CCD coverage.')
-
-        # CCD properties must be valid across the coverage.
-        if np.any(self._row_size[ccd_start:ccd_stop] <= 0.):
-            raise RuntimeError('CCD row size has invalid values <= 0.')
-        if np.any(self._fwhm_resolution[ccd_start:ccd_stop] <= 0.):
-            raise RuntimeError('CCD resolution has invalid values <= 0.')
-        if np.any(self._neff_spatial[ccd_start:ccd_stop] <= 0.):
-            raise RuntimeError('CCD spatial Neff has invalid values <= 0.')
-
-        self.ccd_slice = slice(ccd_start, ccd_stop)
-        self.ccd_coverage = np.zeros_like(self._wavelength, dtype=bool)
-        self.ccd_coverage[ccd_start:ccd_stop] = True
-        self._wavelength_min = self._wavelength[ccd_start]
-        self._wavelength_max = self._wavelength[ccd_stop - 1]
-
-        # Calculate the size of each wavelength bin in units of pixel rows.
-        self._wavelength_bin_size = np.gradient(self._wavelength)
-        neff_wavelength = np.zeros_like(self._neff_spatial)
-        neff_wavelength[self.ccd_slice] = (
-            self._wavelength_bin_size[self.ccd_slice] /
-            self._row_size[self.ccd_slice])
-
-        # Calculate the effective pixel area contributing to the signal
-        # in each wavelength bin.
-        self.neff_pixels = neff_wavelength * self._neff_spatial * u.pixel ** 2
-
-        # Calculate the read noise per wavelength bin, assuming that
-        # readnoise is uncorrelated between pixels (hence the sqrt scaling). The
-        # value will be zero in pixels that are not used by this camera.
-        self.read_noise_per_bin = (
-            self.read_noise * np.sqrt(self.neff_pixels.value) * u.pixel ** 2
-            ).to(u.electron)
-
-        # Calculate the dark current per wavelength bin.
-        self.dark_current_per_bin = (
-            self.dark_current * self.neff_pixels).to(u.electron / u.s)
-
-        # Calculate the RMS resolution assuming a Gaussian PSF.
-        fwhm_to_sigma = 1. / (2 * math.sqrt(2 * math.log(2)))
-        self._rms_resolution = fwhm_to_sigma * self._fwhm_resolution
-
-        # Find the minimum wavelength that can disperse into the CCD,
-        # assuming a constant extrapolation of the resolution.
-        sigma_lo = self._rms_resolution[ccd_start]
-        min_wave = (self._wavelength[ccd_start] -
-                    self.num_sigmas_clip * sigma_lo)
-        if min_wave < self._wavelength[0]:
-            raise RuntimeError(
-                'Wavelength grid min does not cover {0}-camera response.'
-                .format(self.name))
-        matrix_start = np.where(self._wavelength >= min_wave)[0][0]
-
-        # Find the maximum wavelength that can disperse into the CCD,
-        # assuming a constant extrapolation of the resolution.
-        sigma_hi = self._rms_resolution[ccd_stop - 1]
-        max_wave = (self._wavelength[ccd_stop - 1] +
-                    self.num_sigmas_clip * sigma_hi)
-        if max_wave > self._wavelength[-1]:
-            raise RuntimeError(
-                'Wavelength grid max does not cover {0}-camera response.'
-                .format(self.name))
-        matrix_stop = np.where(self._wavelength <= max_wave)[0][-1] + 1
-        self.response_slice = slice(matrix_start, matrix_stop)
-
-        # Pad the RMS array to cover the full resolution matrix range.
-        sigma = np.empty((matrix_stop - matrix_start))
-        sigma[:ccd_start - matrix_start] = sigma_lo
-        sigma[ccd_start - matrix_start:ccd_stop - matrix_start] = (
-            self._rms_resolution[ccd_start:ccd_stop])
-        sigma[ccd_stop - matrix_start:] = sigma_hi
-
-        # Calculate the range of wavelengths where the dispersion will
-        # be evaluated.  The evaluation range extends beyond wavelengths that
-        # can disperse into the CCD in order to calculate the normalization.
-        wave = self._wavelength[matrix_start:matrix_stop]
-        min_wave = wave - self.num_sigmas_clip * sigma
-        max_wave = wave + self.num_sigmas_clip * sigma
-        eval_start = np.searchsorted(self._wavelength, min_wave)
-        eval_stop = np.searchsorted(self._wavelength, max_wave) + 1
-
-        # The columns of the resolution matrix are clipped to the CCD coverage.
-        column_start = np.maximum(eval_start, ccd_start)
-        column_stop = np.minimum(eval_stop, ccd_stop)
-        column_size = column_stop - column_start
-        assert np.all(column_size > 0)
-
-        # Prepare start, stop values for slicing eval -> column.
-        trim_start = column_start - eval_start
-        trim_stop = column_stop - eval_start
-        assert np.all(trim_stop > trim_start)
-
-        # Prepare a sparse resolution matrix in compressed column format.
-        matrix_size = np.sum(column_size)
-        data = np.empty((matrix_size,), float)
-        indices = np.empty((matrix_size,), int)
-        indptr = np.empty((len(column_size) + 1,), int)
-        indptr[0] = 0
-        indptr[1:] = np.cumsum(column_size)
-        assert indptr[-1] == matrix_size
-
-        # Fill sparse matrix arrays.
-        sparse_start = 0
-        for i in xrange(matrix_stop - matrix_start):
-            eval_slice = slice(eval_start[i], eval_stop[i])
-            w = self._wavelength[eval_slice]
-            dw = self._wavelength_bin_size[eval_slice]
-            column = dw * np.exp(-0.5 * ((w - wave[i]) / sigma[i]) ** 2)
-            # Normalize over the full evaluation range.
-            column /= np.sum(column)
-            # Trim to the CCD coverage.
-            s = slice(sparse_start, sparse_start + column_size[i])
-            data[s] = column[trim_start[i]:trim_stop[i]]
-            indices[s] = np.arange(column_start[i], column_stop[i]) - ccd_start
-            sparse_start = s.stop
-        assert np.all((indices >= 0) & (indices < ccd_stop - ccd_start))
-        assert s.stop == matrix_size
-
-        # Create the matrix in CSC format.
-        matrix_shape = (ccd_stop - ccd_start, matrix_stop - matrix_start)
-        self._resolution_matrix = scipy.sparse.csc_matrix(
-            (data, indices, indptr), shape=matrix_shape)
-        # Convert to CSR format for faster matrix multiplies.
-        self._resolution_matrix = self._resolution_matrix.tocsr()
-
-        # Initialize downsampled output pixels.
-        self._output_pixel_size = (
-            output_pixel_size.to(self._wavelength_unit).value)
-        # Check that we can downsample simulation pixels to obtain
-        # output pixels.  This check will only work if the simulation
-        # grid is equally spaced, but no other part of the Camera class
-        # class currently requires this.
-        wavelength_step = self._wavelength[1] - self._wavelength[0]
-        self._downsampling = int(round(
-            self._output_pixel_size / wavelength_step))
-        num_downsampled = int(
-            (self._wavelength_max - self._wavelength_min) //
-            self._output_pixel_size)
-        pixel_edges = (
-            self._wavelength_min - 0.5 * wavelength_step +
-            np.arange(num_downsampled + 1) * self._output_pixel_size)
-        sim_edges = (
-            self._wavelength[self.ccd_slice][::self._downsampling] -
-             0.5 * wavelength_step)
-        if not np.allclose(
-            pixel_edges, sim_edges, rtol=0., atol=1e-6 * wavelength_step):
-            raise ValueError(
-                'Cannot downsample {0}-camera pixels from {1:f} to {2} {3}.'
-                .format(self.name, wavelength_step, self._output_pixel_size,
-                        self._wavelength_unit))
-        # Save the centers of each output pixel.
-        self._output_wavelength = 0.5 * (pixel_edges[1:] + pixel_edges[:-1])
-        # Initialize the parameters used by the downsample() method.
-        self._output_slice = slice(
-            self.ccd_slice.start,
-            self.ccd_slice.start + num_downsampled * self._downsampling)
-        self._downsampled_shape = (num_downsampled, self._downsampling)
-
-
-    def get_output_resolution_matrix(self):
-        """Return the output resolution matrix.
-
-        The output resolution is calculated by summing output pixel
-        blocks of the full resolution matrix.  This is equivalent to
-        the convolution of our resolution with a boxcar representing
-        an output pixel.
-
-        This operation is relatively slow and requires a lot of memory
-        since the full resolution matrix is expanded to a dense array
-        during the calculation.
-
-        The result is returned as a dense matrix but will generally be
-        sparse, so can be converted to one of the scipy.sparse formats.
-        The result is not saved internally.
-
-        Edge effects are not handled very gracefully in order to return
-        a square matrix.
-
-        Returns
-        -------
-        numpy.ndarray
-            Square array of resolution matrix elements.
-        """
-        n = len(self._output_wavelength)
-        m = self._downsampling
-        i0 = self.ccd_slice.start - self.response_slice.start
-        return (self._resolution_matrix[: n * m, i0 : i0 + n * m].toarray()
-                .reshape(n, m, n, m).sum(axis=3).sum(axis=1) / float(m))
-
-
-    def downsample(self, data, method=np.sum):
-        """Downsample data tabulated on the simulation grid to output pixels.
-        """
-        data = np.asanyarray(data)
-        if data.shape != self._wavelength.shape:
-            raise ValueError(
-                'Invalid data shape for downsampling: {0}.'.format(data.shape))
-
-        return method(
-            data[self._output_slice].reshape(self._downsampled_shape), axis=-1)
-
-
-    def apply_resolution(self, flux):
-        """
-        Input should be on the simulation wavelength grid.
-
-        Any throughput should already be applied.
-        """
-        flux = np.asarray(flux)
-        dispersed = np.zeros_like(flux)
-
-        dispersed[self.ccd_slice] = self._resolution_matrix.dot(
-            flux[self.response_slice])
-
-        return dispersed
-
-
-    # Canonical wavelength unit used for all internal arrays.
-    _wavelength_unit = u.Angstrom
-
-
-    @property
-    def wavelength_min(self):
-        """Minimum wavelength covered by this camera's CCD.
-        """
-        return self._wavelength_min * self._wavelength_unit
-
-
-    @property
-    def wavelength_max(self):
-        """Maximum wavelength covered by this camera's CCD.
-        """
-        return self._wavelength_max * self._wavelength_unit
-
-
-    @property
-    def rms_resolution(self):
-        """Array of RMS resolution values.
-        """
-        return self._rms_resolution * self._wavelength_unit
-
-
-    @property
-    def row_size(self):
-        """Array of row sizes in the dispersion direction.
-        """
-        return self._row_size * self._wavelength_unit / u.pixel
-
-
-    @property
-    def neff_spatial(self):
-        """Array of effective pixel dimensions in the spatial (fiber) direction.
-        """
-        return self._neff_spatial * u.pixel
-
-
-    @property
-    def output_pixel_size(self):
-        """Size of output pixels.
-
-        Must be a multiple of the simulation wavelength grid.
-        """
-        return self._output_pixel_size * self._wavelength_unit
-
-
-    @property
-    def output_wavelength(self):
-        """Output pixel central wavelengths.
-        """
-        return self._output_wavelength * self._wavelength_unit
-
-
 def initialize(config):
     """Initialize the instrument model from configuration parameters.
+
+    This method is responsible for creating a new :class:`Instrument` as
+    well as the :class:`Cameras <specsim.camera.Camera>` it includes.
 
     Parameters
     ----------
@@ -749,7 +413,8 @@ def initialize(config):
     Returns
     -------
     Instrument
-        An initialized instrument model.
+        An initialized instrument model including one or more
+        :class:`cameras <specsim.camera.Camera>`.
     """
     name = config.instrument.name
     cameras = config.instrument.cameras
@@ -763,7 +428,7 @@ def initialize(config):
         constants = config.get_constants(camera,
             ['read_noise', 'dark_current', 'gain', 'num_sigmas_clip',
              'output_pixel_size'])
-        initialized_cameras.append(Camera(
+        initialized_cameras.append(specsim.camera.Camera(
             camera_name, config.wavelength, throughput,
             ccd['row_size'], ccd['fwhm_resolution'],
             ccd['neff_spatial'], constants['read_noise'],

--- a/specsim/observation.py
+++ b/specsim/observation.py
@@ -40,5 +40,5 @@ def initialize(config):
         An initialized observation.
     """
     node = config.observation
-    pointing = config.get_sky_coordinate(node.pointing)
+    pointing = config.get_sky(node.pointing)
     return Observation(pointing)

--- a/specsim/observation.py
+++ b/specsim/observation.py
@@ -1,0 +1,44 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Model an astronomical observation for spectroscopic simulations.
+
+An observation is usually initialized from a configuration used to create
+a simulator and then accessible via its ``observation`` attribute, for example:
+
+    >>> import specsim.simulator
+    >>> simulator = specsim.simulator.Simulator('test')
+    >>> print(simulator.observation.pointing)
+    <SkyCoord (ICRS): (ra, dec) in deg
+        (0.0, 0.0)>
+
+After initialization, all aspects of an observation can be modified at runtime.
+"""
+from __future__ import print_function, division
+
+import numpy as np
+
+import astropy.coordinates
+
+
+class Observation(object):
+    """Model the parameters describing a single spectroscopic observation.
+    """
+    def __init__(self, pointing):
+        self.pointing = pointing
+
+
+def initialize(config):
+    """Initialize the observation from configuration parameters.
+
+    Parameters
+    ----------
+    config : :class:`specsim.config.Configuration`
+        The configuration parameters to use.
+
+    Returns
+    -------
+    Observation
+        An initialized observation.
+    """
+    node = config.observation
+    pointing = config.get_sky_coordinate(node.pointing)
+    return Observation(pointing)

--- a/specsim/observation.py
+++ b/specsim/observation.py
@@ -17,6 +17,9 @@ from __future__ import print_function, division
 import numpy as np
 
 import astropy.coordinates
+import astropy.units as u
+
+import specsim.transform
 
 
 class Observation(object):
@@ -24,15 +27,29 @@ class Observation(object):
 
     Parameters
     ----------
+    location : astropy.coordinates.EarthLocation
+        Observatory location on the surface of the earth.
     exposure_time : astropy.units.Quantity
         Open shutter exposure time for this observation.
     pointing : astropy.coordinates.SkyCoord
         Sky position where the telescope boresight is pointing during the
         observation.
+    wavelength : nastropy.units.Quantity
+        Array of wavelength bin centers where the simulated spectrum is
+        calculated, with units.
+    timestamp : astropy.time.Time
+        Time when the shutter opens and the exposure starts.
     """
-    def __init__(self, exposure_time, pointing):
+    def __init__(self, location, exposure_time, exposure_start, pointing,
+                 wavelength,
+                 temperature=15*u.deg_C, pressure=None, relative_humidity=0):
+        self.location = location
         self.exposure_time = exposure_time
+        self.exposure_start = exposure_start
         self.pointing = pointing
+        self.observing_model = specsim.transform.create_observing_model(
+            self.location, self.exposure_start + 0.5 * self.exposure_time,
+            wavelength, temperature, pressure, relative_humidity)
 
 
 def initialize(config):
@@ -50,5 +67,19 @@ def initialize(config):
     """
     node = config.observation
     constants = config.get_constants(config.observation, ['exposure_time'])
+    location = specsim.transform.observatories[node.observatory]
     pointing = config.get_sky(node.pointing)
-    return Observation(constants['exposure_time'], pointing)
+    exposure_start = config.get_timestamp(node.exposure_start)
+    obs = Observation(
+        location, constants['exposure_time'], exposure_start, pointing,
+        config.wavelength)
+
+    if config.verbose:
+        print('Observatory located at {0}.'.format(obs.location))
+        point = obs.pointing.transform_to('icrs')
+        print('Observing field center (ra, dec) = ({0}, {1}).'.format(
+            point.ra, point.dec))
+        print('Exposure start MJD {0:.3f}, duration {1}.'.format(
+            obs.exposure_start.mjd, obs.exposure_time))
+
+    return obs

--- a/specsim/observation.py
+++ b/specsim/observation.py
@@ -21,8 +21,17 @@ import astropy.coordinates
 
 class Observation(object):
     """Model the parameters describing a single spectroscopic observation.
+
+    Parameters
+    ----------
+    exposure_time : astropy.units.Quantity
+        Open shutter exposure time for this observation.
+    pointing : astropy.coordinates.SkyCoord
+        Sky position where the telescope boresight is pointing during the
+        observation.
     """
-    def __init__(self, pointing):
+    def __init__(self, exposure_time, pointing):
+        self.exposure_time = exposure_time
         self.pointing = pointing
 
 
@@ -40,5 +49,6 @@ def initialize(config):
         An initialized observation.
     """
     node = config.observation
+    constants = config.get_constants(config.observation, ['exposure_time'])
     pointing = config.get_sky(node.pointing)
-    return Observation(pointing)
+    return Observation(constants['exposure_time'], pointing)

--- a/specsim/observation.py
+++ b/specsim/observation.py
@@ -119,6 +119,8 @@ def initialize(config):
         hour_angle = astropy.coordinates.Angle(adjust_ha)
         exposure_start = specsim.transform.adjust_time_to_hour_angle(
             nominal_start, point_radec.ra, hour_angle, location.longitude)
+        # Put the requested HA at the middle of the exposure.
+        exposure_start -= 0.5 * constants['exposure_time']
 
     obs = Observation(
         location, constants['exposure_time'], exposure_start, pointing,
@@ -136,8 +138,8 @@ def initialize(config):
             obs.exposure_start.mjd, obs.exposure_time))
         if adjust_ha is not None:
             dt = exposure_start - nominal_start
-            print('Adjusted by {0:+.3f} for {1}.'
-                  .format(dt.to(u.hour), hour_angle.to_string(unit=u.hour)))
+            print('Adjusted by {0:+.3f} for HA {1}.'
+                  .format(dt.to(u.hour), hour_angle))
         cond = obs.observing_model
         print('Conditions: pressure {0:.1f}, temperature {1:.1f}, RH {2:.3f}.'
               .format(cond.pressure, cond.temperature, cond.relative_humidity))

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -163,13 +163,19 @@ class Simulator(object):
         num_source_photons = self.simulated['num_source_photons']
         num_sky_photons = self.simulated['num_sky_photons']
 
-        # Get the source flux incident on the atmosphere.
-        source_flux[:] = self.source.flux_out.to(source_flux.unit)
-
         # Locate the source centroid on the focal plane, as a function
         # of wavelength and time during the exposure.
         focal_x, focal_y = self.observation.locate_on_focal_plane(
             self.source.sky_position, self.instrument)
+
+        # Set the observing airmass in the atmosphere model using
+        # Eqn.3 of Krisciunas & Schaefer 1991.
+        obs_zenith = 90 * u.deg - self.observation.boresight_altaz.alt
+        obs_airmass = (1 - 0.96 * np.sin(obs_zenith) ** 2) ** -0.5
+        self.atmosphere.airmass = obs_airmass
+
+        # Get the source flux incident on the atmosphere.
+        source_flux[:] = self.source.flux_out.to(source_flux.unit)
 
         # Calculate the source flux entering a fiber.
         source_fiber_flux[:] = (

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -28,6 +28,7 @@ import specsim.config
 import specsim.atmosphere
 import specsim.instrument
 import specsim.source
+import specsim.observation
 
 
 class Simulator(object):
@@ -49,6 +50,7 @@ class Simulator(object):
         self.atmosphere = specsim.atmosphere.initialize(config)
         self.instrument = specsim.instrument.initialize(config)
         self.source = specsim.source.initialize(config)
+        self.observation = specsim.observation.initialize(config)
 
         # Initialize our table of simulation results.
         self.camera_names = []

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -153,7 +153,8 @@ class Simulator(object):
         """Simulate a single exposure.
 
         Simulation results are written to internal tables that are overwritten
-        each time this method is called.
+        each time this method is called.  Some metadata is also saved as
+        attributes of this object: `focal_x`, `focal_y`, `fiber_area`.
         """
         # Get references to our results columns.
         wavelength = self.simulated['wavelength']
@@ -176,6 +177,22 @@ class Simulator(object):
         else:
             self.focal_x, self.focal_y = self.source.focal_xy
 
+        # Check that the source is within the field of view.
+        focal_r = np.sqrt(self.focal_x ** 2 + self.focal_y ** 2)
+        if focal_r > self.instrument.field_radius:
+            raise RuntimeError(
+                'Source is located outside the field of view: r = {0:.1f}'
+                .format(focal_r))
+
+        # Calculate the on-sky fiber area at this focal-plane location.
+        radial_fiber_size = (
+            0.5 * self.instrument.fiber_diameter /
+            self.instrument.radial_scale(focal_r))
+        azimuthal_fiber_size = (
+            0.5 * self.instrument.fiber_diameter /
+            self.instrument.azimuthal_scale(focal_r))
+        self.fiber_area = np.pi * radial_fiber_size * azimuthal_fiber_size
+
         # Get the source flux incident on the atmosphere.
         source_flux[:] = self.source.flux_out.to(source_flux.unit)
 
@@ -189,7 +206,7 @@ class Simulator(object):
         # Calculate the sky flux entering a fiber.
         sky_fiber_flux[:] = (
             self.atmosphere.surface_brightness *
-            self.instrument.fiber_area
+            self.fiber_area
             ).to(sky_fiber_flux.unit)
 
         # Calculate the mean number of source photons entering the fiber

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -166,6 +166,11 @@ class Simulator(object):
         # Get the source flux incident on the atmosphere.
         source_flux[:] = self.source.flux_out.to(source_flux.unit)
 
+        # Locate the source centroid on the focal plane, as a function
+        # of wavelength and time during the exposure.
+        focal_x, focal_y = self.observation.locate_on_focal_plane(
+            self.source.sky_position, self.instrument)
+
         # Calculate the source flux entering a fiber.
         source_fiber_flux[:] = (
             source_flux *

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -163,16 +163,18 @@ class Simulator(object):
         num_source_photons = self.simulated['num_source_photons']
         num_sky_photons = self.simulated['num_sky_photons']
 
-        # Locate the source centroid on the focal plane, as a function
-        # of wavelength and time during the exposure.
-        focal_x, focal_y = self.observation.locate_on_focal_plane(
-            self.source.sky_position, self.instrument)
+        # Locate the source centroid on the focal plane.
+        if self.source.focal_xy is None:
+            self.focal_x, self.focal_y = self.observation.locate_on_focal_plane(
+                self.source.sky_position, self.instrument)
 
-        # Set the observing airmass in the atmosphere model using
-        # Eqn.3 of Krisciunas & Schaefer 1991.
-        obs_zenith = 90 * u.deg - self.observation.boresight_altaz.alt
-        obs_airmass = (1 - 0.96 * np.sin(obs_zenith) ** 2) ** -0.5
-        self.atmosphere.airmass = obs_airmass
+            # Set the observing airmass in the atmosphere model using
+            # Eqn.3 of Krisciunas & Schaefer 1991.
+            obs_zenith = 90 * u.deg - self.observation.boresight_altaz.alt
+            obs_airmass = (1 - 0.96 * np.sin(obs_zenith) ** 2) ** -0.5
+            self.atmosphere.airmass = obs_airmass
+        else:
+            self.focal_x, self.focal_y = self.source.focal_xy
 
         # Get the source flux incident on the atmosphere.
         source_flux[:] = self.source.flux_out.to(source_flux.unit)

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -10,7 +10,7 @@ configuration.  Certain parameters can also be changed after a model has
 been initialized, for example:
 
     >>> simulator.atmosphere.airmass = 1.5
-    >>> simulator.instrument.exposure_time = 1200 * u.s
+    >>> simulator.observation.exposure_time = 1200 * u.s
 
 See :mod:`source`, :mod:`atmosphere` and :mod:`instrument` for details.
 """
@@ -184,7 +184,7 @@ class Simulator(object):
         num_source_photons[:] = (
             source_fiber_flux *
             self.instrument.photons_per_bin *
-            self.instrument.exposure_time
+            self.observation.exposure_time
             ).to(1).value
 
         # Calculate the mean number of sky photons entering the fiber
@@ -192,7 +192,7 @@ class Simulator(object):
         num_sky_photons[:] = (
             sky_fiber_flux *
             self.instrument.photons_per_bin *
-            self.instrument.exposure_time
+            self.observation.exposure_time
             ).to(1).value
 
         # Calculate the calibration from constant unit source flux above
@@ -203,7 +203,7 @@ class Simulator(object):
             self.atmosphere.extinction *
             self.instrument.get_fiber_acceptance(self.source) *
             self.instrument.photons_per_bin *
-            self.instrument.exposure_time).to(source_flux.unit ** -1).value
+            self.observation.exposure_time).to(source_flux.unit ** -1).value
 
         # Loop over cameras to calculate their individual responses.
         for output, camera in zip(self.camera_output, self.instrument.cameras):
@@ -229,7 +229,7 @@ class Simulator(object):
             # Calculate the mean number of dark current electrons in the CCD.
             num_dark_electrons[:] = (
                 camera.dark_current_per_bin *
-                self.instrument.exposure_time).to(u.electron).value
+                self.observation.exposure_time).to(u.electron).value
 
             # Copy the read noise in units of electrons.
             read_noise_electrons[:] = (
@@ -324,7 +324,7 @@ class Simulator(object):
             title = (
                 '{0}, X={1}, t={2}'
                 .format(self.source.name, self.atmosphere.airmass,
-                        self.instrument.exposure_time))
+                        self.observation.exposure_time))
         plot_simulation(self.simulated, self.camera_output, title)
 
 

--- a/specsim/source.py
+++ b/specsim/source.py
@@ -280,18 +280,14 @@ def initialize(config):
     table = config.load_table(
         config.source, ['wavelength', 'flux'], interpolate=False)
     # Get the position of this source.
-    if hasattr(config.source.location, 'constants'):
-        constants = config.get_constants(
-            config.source.location, ['focal_x', 'focal_y'])
+    constants = config.get_constants(
+        config.source.location, optional_names=['focal_x', 'focal_y'])
+    if 'focal_x' in constants and 'focal_y' in constants:
         focal_xy = constants['focal_x'], constants['focal_y']
-        # Sky position is optional when x,y are specified.
-        if hasattr(config.source.location, 'sky'):
-            sky_position = config.get_sky(config.source.location)
-        else:
-            sky_position = None
     else:
         focal_xy = None
-        # Sky position is required when (x,y) are not specified.
+    # Sky position is optional (and ignored) when x,y are specified.
+    if hasattr(config.source.location, 'sky'):
         sky_position = config.get_sky(config.source.location)
     # Create a new Source object.
     source = Source(

--- a/specsim/source.py
+++ b/specsim/source.py
@@ -81,6 +81,8 @@ class Source(object):
         self.update_in(name, type_name, wavelength_in, flux_in, z_in)
         self.update_out(z_out, filter_name, ab_magnitude_out)
 
+        self.sky_position = sky_position
+
 
     def update_in(self, name, type_name, wavelength_in, flux_in, z_in=None):
         """Update this source model.

--- a/specsim/tests/test_camera.py
+++ b/specsim/tests/test_camera.py
@@ -1,0 +1,19 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import print_function, division
+
+import numpy as np
+
+import astropy.units as u
+from astropy.tests.helper import pytest
+
+from ..camera import *
+
+import specsim.instrument
+import specsim.config
+
+
+def test_resolution():
+    c = specsim.config.load_config('test')
+    i = specsim.instrument.initialize(c)
+    R = i.cameras[0].get_output_resolution_matrix()
+    np.allclose(R.sum(0)[3:-3], 1)

--- a/specsim/tests/test_config.py
+++ b/specsim/tests/test_config.py
@@ -80,6 +80,17 @@ def test_parse_quantity():
     assert parse_quantity('1.23 m') == 1.23 * u.m
     assert parse_quantity('1.23 m/s') == 1.23 * u.m / u.s
     assert parse_quantity('1.23 m / s') == 1.23 * u.m / u.s
+    with pytest.raises(ValueError):
+        parse_quantity('123 abc')
+    with pytest.raises(ValueError):
+        parse_quantity('m/s')
+
+
+def test_parse_dimensions():
+    assert parse_quantity('1min', 's') == 60 * u.s
+    assert parse_quantity('1min', u.s) == 60 * u.s
+    with pytest.raises(ValueError):
+        parse_quantity('1m', u.s)
 
 
 def test_table():

--- a/specsim/tests/test_config.py
+++ b/specsim/tests/test_config.py
@@ -73,6 +73,15 @@ def test_constants():
     assert const['dark_current'] == 2.0 * u.electron / (u.hour * u.pixel**2)
 
 
+def test_parse_quantity():
+    assert parse_quantity('1') == u.Quantity(1)
+    assert parse_quantity('1.23') == u.Quantity(1.23)
+    assert parse_quantity('1.23m') == 1.23 * u.m
+    assert parse_quantity('1.23 m') == 1.23 * u.m
+    assert parse_quantity('1.23 m/s') == 1.23 * u.m / u.s
+    assert parse_quantity('1.23 m / s') == 1.23 * u.m / u.s
+
+
 def test_table():
     config = load_config('test')
     t = config.load_table(config.source, 'flux')

--- a/specsim/tests/test_instrument.py
+++ b/specsim/tests/test_instrument.py
@@ -14,13 +14,6 @@ import matplotlib
 matplotlib.use('Agg') # Must be before importing matplotlib.pyplot or pylab!
 
 
-def test_resolution():
-    c = specsim.config.load_config('test')
-    i = initialize(c)
-    R = i.cameras[0].get_output_resolution_matrix()
-    np.allclose(R.sum(0)[3:-3], 1)
-
-
 def test_plot():
     c = specsim.config.load_config('test')
     i = initialize(c)

--- a/specsim/tests/test_instrument.py
+++ b/specsim/tests/test_instrument.py
@@ -25,3 +25,9 @@ def test_plot():
     c = specsim.config.load_config('test')
     i = initialize(c)
     i.plot()
+
+
+def test_distortion_plot():
+    c = specsim.config.load_config('test')
+    i = initialize(c)
+    i.plot_field_distortion()

--- a/specsim/tests/test_instrument.py
+++ b/specsim/tests/test_instrument.py
@@ -24,4 +24,4 @@ def test_resolution():
 def test_plot():
     c = specsim.config.load_config('test')
     i = initialize(c)
-    i.plot()
+    i.plot(exposure_time=1000 * u.s)

--- a/specsim/tests/test_instrument.py
+++ b/specsim/tests/test_instrument.py
@@ -24,4 +24,4 @@ def test_resolution():
 def test_plot():
     c = specsim.config.load_config('test')
     i = initialize(c)
-    i.plot(exposure_time=1000 * u.s)
+    i.plot()

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -39,6 +39,8 @@ low_altitude_threshold : :class:`astropy.coordinates.Angle`
     will issue a `UserWarning` if they encounter a lower value, unless
     refraction has been disabled by specifying zero pressure.
 """
+from __future__ import print_function, division
+
 import warnings
 
 import numpy as np

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -524,31 +524,35 @@ def adjust_time_to_hour_angle(nominal_time, target_ra, hour_angle,
     when = nominal_time.copy()
     num_iterations = 0
     while True:
-        # Calculate the nominal local sidereal time of the target.
-        try:
-            lst = when.sidereal_time('apparent', longitude) - target_ra
-        # Recent versions of astropy raise a subclass of IndexError
-        # astropy.utils.iers.iers.IERSRangeError
-        except IndexError:
-            # Hardcode the mean UT1 - UTC offset for MJD in [54600, 57800]
-            # in order to avoid issues with missing IERS tables.
-            when.delta_ut1_utc = -0.1225
-            lst = when.sidereal_time('apparent', longitude) - target_ra
+        with warnings.catch_warnings():
+            # Ignore the UnicodeWarning that occurs in the astropy
+            # implementation of sidereal_time().
+            warnings.filterwarnings('ignore', 'Unicode')
+            # Calculate the nominal local sidereal time of the target.
+            try:
+                lst = when.sidereal_time('apparent', longitude) - target_ra
+            # Recent versions of astropy raise a subclass of IndexError
+            # astropy.utils.iers.iers.IERSRangeError
+            except IndexError:
+                # Hardcode the mean UT1 - UTC offset for MJD in [54600, 57800]
+                # in order to avoid issues with missing IERS tables.
+                when.delta_ut1_utc = -0.1225
+                lst = when.sidereal_time('apparent', longitude) - target_ra
 
-        # Are we close enough?
-        if np.abs((lst - hour_angle).wrap_at('12 hours')) <= max_error:
-            break
+            # Are we close enough?
+            if np.abs((lst - hour_angle).wrap_at('12 hours')) <= max_error:
+                break
 
-        # Have we run out of iterations?
-        if num_iterations >= max_iterations:
-            raise RuntimeError(
-                'Reached max_iterations = {}.'.format(max_iterations))
-        num_iterations += 1
+            # Have we run out of iterations?
+            if num_iterations >= max_iterations:
+                raise RuntimeError(
+                    'Reached max_iterations = {}.'.format(max_iterations))
+            num_iterations += 1
 
-        # Offset to the nearest time with the desired hour angle.
-        # Correct for the fact that 360 deg corresponds to a sidereal day.
-        when = (when - (lst - hour_angle).wrap_at('12 hours') * u.hour /
-                (15 * u.deg) * sidereal)
+            # Offset to the nearest time with the desired hour angle.
+            # Correct for the fact that 360 deg corresponds to a sidereal day.
+            when = (when - (lst - hour_angle).wrap_at('12 hours') * u.hour /
+                    (15 * u.deg) * sidereal)
 
     return when
 


### PR DESCRIPTION
This is the first major piece of adding simulation realism. The simulation now knows about the plate scale variation across the focal plane and can locate simulated sources on the focal plane, resulting in the correct variation of on-sky fiber area and shape.

The next step is to upgrade the fiber acceptance fraction calculations #5 so that the source throughput reflects focal plane position (currently only the sky background level reflects the on-sky fiber area).

Fixes #24.
