### PR TITLE
compatible with py2 and py3 without 2to3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(name=PACKAGENAME,
       long_description=LONG_DESCRIPTION,
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=True,
+      use_2to3=False,
       entry_points=entry_points,
       **package_info
 )

--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -191,7 +191,7 @@ class Camera(object):
 
         # Fill sparse matrix arrays.
         sparse_start = 0
-        for i in xrange(matrix_stop - matrix_start):
+        for i in range(matrix_stop - matrix_start):
             eval_slice = slice(eval_start[i], eval_stop[i])
             w = self._wavelength[eval_slice]
             dw = self._wavelength_bin_size[eval_slice]

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -41,6 +41,10 @@ import astropy.utils.data
 import astropy.coordinates
 import astropy.time
 
+try:
+    basestring          #- exists in py2
+except NameError:
+    basestring = str    #- for py3
 
 # Extract a number from a string with optional leading and
 # trailing whitespace.
@@ -370,7 +374,7 @@ class Configuration(Node):
             # Look for parent.table.path first.
             paths.append(os.path.join(self.abs_base_path, node.path))
         except AttributeError:
-            path_keys = node.paths.keys()
+            path_keys = list(node.paths.keys())
             for key in path_keys:
                 path = getattr(node.paths, key)
                 paths.append(os.path.join(self.abs_base_path, path))

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -30,6 +30,10 @@ import specsim.instrument
 import specsim.source
 import specsim.observation
 
+try:
+    basestring          #- exists in py2
+except NameError:
+    basestring = str    #- for py3
 
 class Simulator(object):
     """Manage the simulation of a source, atmosphere and instrument.

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from __future__ import absolute_import, division, print_function
+
 from astropy.tests.helper import pytest, remote_data
 from ..transform import altaz_to_focalplane, focalplane_to_altaz, \
     observatories, create_observing_model, sky_to_altaz, altaz_to_sky, \
@@ -180,7 +182,7 @@ def test_alt_warn_pressure_array():
         altaz_to_sky(alt, 0*u.deg, obs_model)
     alt = np.array([alt0 - 1, alt0 + 1]) * u.deg
     with pytest.raises(UserWarning):
-        print altaz_to_sky(alt[:, np.newaxis], 0*u.deg, obs_model).shape
+        print(altaz_to_sky(alt[:, np.newaxis], 0*u.deg, obs_model).shape)
 
 
 @remote_data

--- a/specsim/transform.py
+++ b/specsim/transform.py
@@ -50,6 +50,10 @@ import astropy.coordinates
 import astropy.constants
 from astropy import units as u
 
+try:
+    basestring          #- exists in py2
+except NameError:
+    basestring = str    #- for py3
 
 observatories = {
     'APO': astropy.coordinates.EarthLocation.from_geodetic(


### PR DESCRIPTION
This PR fixes #47 by making the code genuinely py2.7 and 3.5 compatible, rather than relying upon 2to3 conversions to be applied on-the-fly during installation.  Most changes are innocuous, though I'll admit that this is a bit yucky:
```python
try:
    basestring          #- exists in py2
except NameError:
    basestring = str    #- for py3
```
I set `use_2to3=False` in setup.py so that any other non-py3 compatible changes will trigger a test failure.  If that becomes problematic we could revert to `use_2to3=True`, but in the meantime it would be handy to have the code natively be py3.5 compatible.