### PR TITLE
Re-implement Camera.get_output_resolution_matrix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@
 ----------------
 
 - Create DOI for v0.5 https://doi.org/10.5281/zenodo.154130.
+- Re-implement Camera.get_output_resolution_matrix to return a sparse
+  matrix, which uses significantly less memory and runs 4-5x faster.
 
 0.5 (2016-09-12)
 ----------------

--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -248,7 +248,7 @@ class Camera(object):
 
 
     def get_output_resolution_matrix(self):
-        """Return the output resolution matrix in CSR sparse format.
+        """Return the output resolution matrix in DIA sparse format.
 
         The output resolution is calculated by summing output pixel
         blocks of the full resolution matrix.  This is equivalent to
@@ -261,14 +261,10 @@ class Camera(object):
         not used internally and is re-calcuated each time this method
         is called.
 
-        The output is a CSR-format sparse matrix, which is optimized for
-        fast matrix-vector products and can be efficiently converted to
-        the DIA sparse format using :meth:`scipy.sparse.csr_matrix.todia`.
-
         Returns
         -------
-        numpy.ndarray
-            Square array of resolution matrix elements in the CSR
+        :class:`scipy.sparse.dia_matrix`
+            Square array of resolution matrix elements in the DIA
             sparse format.
         """
         n = len(self._output_wavelength)
@@ -314,8 +310,10 @@ class Camera(object):
         indices_out = np.hstack(indices_out)
 
         # Build the output matrix in CSR format.
-        return scipy.sparse.csr_matrix(
-            (data_out, indices_out, indptr_out), (n, n))
+        R = scipy.sparse.csr_matrix((data_out, indices_out, indptr_out), (n, n))
+
+        # Convert to DIA format and return.
+        return R.todia()
 
 
     def downsample(self, data, method=np.sum):

--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -253,18 +253,17 @@ class Camera(object):
         The output resolution is calculated by summing output pixel
         blocks of the full resolution matrix.  This is equivalent to
         the convolution of our resolution with a boxcar representing
-        an output pixel.
+        an output pixel. Edge effects are not handled very gracefully
+        in order to return a square matrix.
 
         The memory required for this operation scales with the number
-        of non-zero elements in the returned matrix. The result is not
-        cached.
+        of non-zero elements in the returned matrix. This matrix is
+        not used internally and is re-calcuated each time this method
+        is called.
 
         The output is a CSR-format sparse matrix, which is optimized for
         fast matrix-vector products and can be efficiently converted to
-        the DIA sparse format.
-
-        Edge effects are not handled very gracefully in order to return
-        a square matrix.
+        the DIA sparse format using :meth:`scipy.sparse.csr_matrix.todia`.
 
         Returns
         -------

--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -248,20 +248,20 @@ class Camera(object):
 
 
     def get_output_resolution_matrix(self):
-        """Return the output resolution matrix.
+        """Return the output resolution matrix in CSR sparse format.
 
         The output resolution is calculated by summing output pixel
         blocks of the full resolution matrix.  This is equivalent to
         the convolution of our resolution with a boxcar representing
         an output pixel.
 
-        This operation is relatively slow and requires a lot of memory
-        since the full resolution matrix is expanded to a dense array
-        during the calculation.
+        The memory required for this operation scales with the number
+        of non-zero elements in the returned matrix. The result is not
+        cached.
 
-        The result is returned as a dense matrix but will generally be
-        sparse, so can be converted to one of the scipy.sparse formats.
-        The result is not saved internally.
+        The output is a CSR-format sparse matrix, which is optimized for
+        fast matrix-vector products and can be efficiently converted to
+        the DIA sparse format.
 
         Edge effects are not handled very gracefully in order to return
         a square matrix.
@@ -269,41 +269,54 @@ class Camera(object):
         Returns
         -------
         numpy.ndarray
-            Square array of resolution matrix elements.
+            Square array of resolution matrix elements in the CSR
+            sparse format.
         """
         n = len(self._output_wavelength)
         m = self._downsampling
         i0 = self.ccd_slice.start - self.response_slice.start
-        # Initialize CSR format arrays for the output matrix.
+        output_slice = slice(i0, i0 + n * m)
+        # Initialize CSR format arrays for building the output matrix.
         indptr_out = np.empty((n + 1,), int)
         indices_out = []
         data_out = []
+        row_size = self._resolution_matrix.shape[1]
+        cols_sum = np.empty(row_size, int)
+        data_sum = np.empty(row_size, float)
         # Loop over rows of the CSR format sparse data.
-        indices = self._resolution_matrix.indices
-        indptr = self._resolution_matrix.indptr
-        data = self._resolution_matrix.data
-        cols_sum = np.empty(n * m, int)
-        data_sum = np.empty(n * m, float)
+        indices_in = self._resolution_matrix.indices
+        indptr_in = self._resolution_matrix.indptr
+        data_in = self._resolution_matrix.data
+        # Loop over rows in the full resolution matrix.
+        num_out = 0
         for i in range(0, n * m, m):
             cols_sum[:] = 0
+            data_sum[:] = 0.
+            # Loop over rows that will be combined into a single output row.
             for k in range(i, i + m):
+                packed = slice(indptr_in[k], indptr_in[k + 1])
                 # Find the columns with data in this row.
-                cols = indices[indptr[k]: indptr[k + 1]]
-                # Trim columns outside of our downsampling window.
-                trimmed = (cols >= i0) & (cols < i0 + n * m)
-                cols = cols[trimmed] - i0
+                expanded = indices_in[packed]
                 # Count the rows contributing to each column.
-                cols_sum[cols] += 1
+                cols_sum[expanded] += 1
                 # Sum the data across rows for each column.
-                data_sum[cols] += data[indptr[k]: indptr[k + 1]][trimmed]
-            cols_out = cols_sum.reshape(n, m).sum(axis=1)
-            nonzero = np.where(cols_out > 0)[0]
-            indptr_out[i // m] = nonzero[0]
-            indptr_out[(i // m) + 1] = nonzero[-1] + 1
-            #data_out = data_sum.reshape(n, m).sum(axis=1) / float(m)
+                data_sum[expanded] += data_in[packed]
+            # Combine into a single output row.
+            data = data_sum[output_slice].reshape(n, m).sum(axis=1) / m
+            counts = cols_sum[output_slice].reshape(n, m).sum(axis=1)
+            indices = np.where(counts > 0)[0]
+            indices_out.append(indices)
+            data_out.append(data[indices])
+            indptr_out[i // m] = num_out
+            num_out += len(indices)
+            indptr_out[(i // m) + 1] = num_out
+        # Combine row arrays.
+        data_out = np.hstack(data_out)
+        indices_out = np.hstack(indices_out)
 
-        return (self._resolution_matrix[: n * m, i0 : i0 + n * m].toarray()
-                .reshape(n, m, n, m).sum(axis=3).sum(axis=1) / float(m))
+        # Build the output matrix in CSR format.
+        return scipy.sparse.csr_matrix(
+            (data_out, indices_out, indptr_out), (n, n))
 
 
     def downsample(self, data, method=np.sum):

--- a/specsim/tests/test_camera.py
+++ b/specsim/tests/test_camera.py
@@ -16,4 +16,24 @@ def test_resolution():
     c = specsim.config.load_config('test')
     i = specsim.instrument.initialize(c)
     R = i.cameras[0].get_output_resolution_matrix()
-    np.allclose(R.sum(0)[3:-3], 1)
+    assert np.allclose(R.sum(0)[3:-3], 1)
+
+
+def test_downsampling():
+    c = specsim.config.load_config('test')
+    i = specsim.instrument.initialize(c)
+    camera = i.cameras[0]
+
+    # Use an intermediate dense matrix for downsampling.
+    # This is the old implementation of get_output_resolution_matrix()
+    # that used too much memory.
+    n = len(camera._output_wavelength)
+    m = camera._downsampling
+    i0 = camera.ccd_slice.start - camera.response_slice.start
+    R1 = (camera._resolution_matrix[: n * m, i0 : i0 + n * m].toarray()
+         .reshape(n, m, n, m).sum(axis=3).sum(axis=1) / float(m))
+
+    # Use the new sparse implementation of get_output_resolution_matrix().
+    R2 = camera.get_output_resolution_matrix() #.toarray()
+
+    assert np.allclose(R1, R2)

--- a/specsim/tests/test_camera.py
+++ b/specsim/tests/test_camera.py
@@ -26,7 +26,7 @@ def test_downsampling():
 
     # Use an intermediate dense matrix for downsampling.
     # This is the old implementation of get_output_resolution_matrix()
-    # that used too much memory.
+    # which uses too much memory.
     n = len(camera._output_wavelength)
     m = camera._downsampling
     i0 = camera.ccd_slice.start - camera.response_slice.start
@@ -34,6 +34,6 @@ def test_downsampling():
          .reshape(n, m, n, m).sum(axis=3).sum(axis=1) / float(m))
 
     # Use the new sparse implementation of get_output_resolution_matrix().
-    R2 = camera.get_output_resolution_matrix() #.toarray()
+    R2 = camera.get_output_resolution_matrix()
 
-    assert np.allclose(R1, R2)
+    assert np.allclose(R1, R2.toarray())


### PR DESCRIPTION
Camera.get_output_resolution_matrix() now returns a DIA-format sparse matrix, which uses significantly less memory and runs 4-5x faster.

A new unit test compares the previous dense downsampling algorithm with the new sparse algorithm to ensure that the values are `np.allclose`.

This is ready for review and merge and fixes #43.

Since the `desispec.resolution.Resolution` constructor accepts either a dense or DIA-sparse matrix, no API changes should be required for these `desisim` lines in `quickbrick.py`:
```
R = Resolution(camera.get_output_resolution_matrix())
```
and `quickgen.py`:
```
resolution_matrix = Resolution(
   qsim.instrument.cameras[i].get_output_resolution_matrix())
```
However, the internals of the Resolution constructor might need some work if the list of diagonals provided does not match what the brick datamodel expects.