### PR TITLE
Implement accurate and flexible fiberloss calculations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,9 @@
 0.7 (unreleased)
 ----------------
 
-No changes yet.
+- Add fiberloss module with support for more realistic fiberloss calculations.
+- Add optional dependency on galsim (only required for on-the-fly fiberloss
+  calculations).
 
 0.6 (2016-11-09)
 ----------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -62,6 +62,10 @@ repeating the initialization step, for example::
 .. automodapi:: specsim.observation
     :no-inheritance-diagram:
 
+.. fiberloss-api:
+.. automodapi:: specsim.fiberloss
+    :no-inheritance-diagram:
+
 .. _simulator-api:
 .. automodapi:: specsim.simulator
     :no-inheritance-diagram:

--- a/specsim/atmosphere.py
+++ b/specsim/atmosphere.py
@@ -194,7 +194,7 @@ class Atmosphere(object):
             Full-width half maximum of seeing distribution at the specified
             wavelength, in on-sky angular units.
         """
-        wlen_ratio = np.float((wavelength / wavelength_ref).si)
+        wlen_ratio = np.float((wavelength / self.seeing['wlen_ref']).si)
         return self.seeing['fwhm_ref'] * wlen_ratio ** (-0.2)
 
 

--- a/specsim/atmosphere.py
+++ b/specsim/atmosphere.py
@@ -177,6 +177,27 @@ class Atmosphere(object):
             self.moon.airmass = airmass
 
 
+    def get_seeing_fwhm(self, wavelength):
+        """Calculate the seeing FWHM at the specified wavelength.
+
+        Assumes that seeing scales with wavelength with a power -1/5, as
+        predicted by Kolmogorov turbulence theory.
+
+        Parameters
+        ----------
+        wavelength : astropy.units.Quantity
+            Wavelength in units convertible to Angstroms.
+
+        Returns
+        -------
+        astropy.units.Quantity
+            Full-width half maximum of seeing distribution at the specified
+            wavelength, in on-sky angular units.
+        """
+        wlen_ratio = np.float((wavelength / wavelength_ref).si)
+        return self.seeing['fwhm_ref'] * wlen_ratio ** (-0.2)
+
+
     def plot(self):
         """Plot a summary of this atmosphere model.
 

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -52,7 +52,7 @@ _float_pattern = re.compile(
     '\s*([-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)\s*')
 
 
-def parse_quantity(string, dimensions=None):
+def parse_quantity(quantity, dimensions=None):
     """Parse a string containing a numeric value with optional units.
 
     The result is a :class:`Quantity <astropy.units.Quantity` object even
@@ -68,8 +68,9 @@ def parse_quantity(string, dimensions=None):
 
     Parameters
     ----------
-    string : str
-        String to parse.
+    quantity : str or astropy.units.Quantity
+        String to parse.  If a quantity is provided, it is checked against
+        the expected dimensions and passed through.
     dimensions : str or astropy.units.Unit or None
         The units of the input quantity are expected to have the same
         dimensions as these units, if not None.  Raises a ValueError if
@@ -86,13 +87,14 @@ def parse_quantity(string, dimensions=None):
     ValueError
         Unable to parse quantity.
     """
-    # Look for a valid number starting the string.
-    found_number = _float_pattern.match(string)
-    if not found_number:
-        raise ValueError('Unable to parse quantity.')
-    value = float(found_number.group(1))
-    unit = string[found_number.end():]
-    quantity = astropy.units.Quantity(value, unit)
+    if not isinstance(quantity, astropy.units.Quantity):
+        # Look for a valid number starting the string.
+        found_number = _float_pattern.match(quantity)
+        if not found_number:
+            raise ValueError('Unable to parse quantity.')
+        value = float(found_number.group(1))
+        unit = quantity[found_number.end():]
+        quantity = astropy.units.Quantity(value, unit)
     if dimensions is not None:
         try:
             if not isinstance(dimensions, astropy.units.Unit):

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -508,7 +508,6 @@ class Configuration(Node):
         path = os.path.join(self.abs_base_path, node.path)
         fmt = getattr(node, 'format', None)
         table = astropy.table.Table.read(path, format=fmt)
-        print(table)
         ny = len(table)
         y_col = table[y_column_name]
         y_value = np.array(y_col.data)
@@ -559,7 +558,7 @@ class Configuration(Node):
             get_y = lambda y: y.to(y_unit).value
         else:
             get_y = lambda y: np.asarray(y)
-        return lambda x, y: interpolator(get_x(x), get_y(y)) * data_unit
+        return lambda x, y: interpolator.ev(get_x(x), get_y(y)) * data_unit
 
 
 def load_config(name, config_type=Configuration):

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -40,6 +40,7 @@ import astropy.table
 import astropy.utils.data
 import astropy.coordinates
 import astropy.time
+import astropy.io.fits
 
 try:
     basestring          #- exists in py2
@@ -332,6 +333,13 @@ class Configuration(Node):
                 raise RuntimeError('Invalid value for {0}.{1}: {2}'
                                    .format(node, name, value))
         return constants
+
+
+    def load_fits(self, filename, **kwargs):
+        """Load the specified FITS file.
+        """
+        path = os.path.join(self.abs_base_path, filename)
+        return astropy.io.fits.open(path, **kwargs)
 
 
     def load_table(self, parent, column_names, interpolate=True, as_dict=False):

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -335,13 +335,6 @@ class Configuration(Node):
         return constants
 
 
-    def load_fits(self, filename, **kwargs):
-        """Load the specified FITS file.
-        """
-        path = os.path.join(self.abs_base_path, filename)
-        return astropy.io.fits.open(path, **kwargs)
-
-
     def load_table(self, parent, column_names, interpolate=True, as_dict=False):
         """Load and interpolate tabular data from one or more files.
 
@@ -567,6 +560,22 @@ class Configuration(Node):
         else:
             get_y = lambda y: np.asarray(y)
         return lambda x, y: interpolator.ev(get_x(x), get_y(y)) * data_unit
+
+
+    def load_fits2d(self, filename, **hdus):
+        """Load the specified FITS file.
+        """
+        path = os.path.join(self.abs_base_path, filename)
+        fits = astropy.io.fits.open(path, memmap=False)
+        interpolators = {}
+        for name in hdus:
+            #x = ...
+            #y = ...
+            data = fits[hdus[name]].data
+            #interpolators[hdu] = scipy.interpolate.RectBivariateSpline(
+            #    x, y, data, kx=1, ky=1, s=0)
+        fits.close()
+        return interpolators
 
 
 def load_config(name, config_type=Configuration):

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -613,9 +613,15 @@ class Configuration(Node):
                                  .format(bunit, hdus[name]))
             dimensionless_interpolator = scipy.interpolate.RectBivariateSpline(
                 x, y, hdu.data, kx=1, ky=1, s=0)
-            interpolators[hdu] = (
-                lambda x, y: dimensionless_interpolator(
-                    x.to(xy_unit).value, y.to(xy_unit).value) * bunit)
+            # Note that the default arg values are used to capture the
+            # current values of dimensionless_interpolator and data_unit
+            # in the closure of this inner function.
+            def interpolator(x, y, f=dimensionless_interpolator, u=data_unit):
+                return f.ev(x.to(xy_unit).value, y.to(xy_unit).value) * u
+            interpolators[name] = interpolator
+            if self.verbose:
+                print('Loaded {0} from HDU[{1}] of {2}.'
+                      .format(name, hdus[name], path))
         hdu_list.close()
         return interpolators
 

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -551,16 +551,20 @@ class Configuration(Node):
         interpolator = scipy.interpolate.RectBivariateSpline(
             x_value, y_value, data, kx=1, ky=1, s=0)
 
-        # Return a wrapper that handles units.
+        # Return a wrapper that handles units.  Note that default parameters
+        # are used below to capture values (rather than references) in the
+        # lambda closures.
         if x_unit != 1:
-            get_x = lambda x: x.to(x_unit).value
+            get_x = lambda x, u=x_unit: x.to(u).value
         else:
             get_x = lambda x: np.asarray(x)
         if y_unit != 1:
-            get_y = lambda y: y.to(y_unit).value
+            get_y = lambda y, u=y_unit: y.to(u).value
         else:
             get_y = lambda y: np.asarray(y)
-        return lambda x, y: interpolator.ev(get_x(x), get_y(y)) * data_unit
+        return (
+            lambda x, y, f=interpolator, u=data_unit:
+            f.ev(get_x(x), get_y(y)) * u)
 
 
     def load_fits2d(self, filename, xy_unit, **hdus):

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -102,7 +102,7 @@ def parse_quantity(quantity, dimensions=None):
             quantity = quantity.to(dimensions)
         except (ValueError, astropy.units.UnitConversionError):
             raise ValueError('Quantity "{0}" is not convertible to {1}.'
-                             .format(string, dimensions))
+                             .format(quantity, dimensions))
     return quantity
 
 

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -124,7 +124,7 @@ instrument:
         method: galsim
         # Number of wavelengths where fiberloss should be calculated
         # and interpolated. Ignored unless method is galsim.
-        ngrid: 11
+        num_wlen: 11
         # Pixel size for numerically integrating flux into the fiber.
         # Ignored unless method is galsim.
         pixel_size: 0.05 arcsec

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -285,8 +285,11 @@ source:
                 # Note the factor of 1e-17 in the units!
                 unit: 1e-17 erg / (Angstrom cm2 s)
     # Transverse profile of the source on the sky, used to calculate the
-    # fiberloss fraction.
+    # fiberloss fraction when instrument.fiberloss.method = galsim (but
+    # ignored otherwise).
     profile:
+        # If the pointlike_fraction is 1, all other parameters are ignored.
+        pointlike_fraction: 0.0
         disk_fraction: 0.5
         disk_shape:
             half_light_radius: 0.8 arcsec

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -145,6 +145,13 @@ instrument:
         path: throughput/DESI-0347_blur.ecsv
         # The ECSV format is not auto-detected so we specify it explicitly.
         format: ascii.ecsv
+    offset:
+        # Read radial centroid offsets tabulated as a function of field angle
+        # and wavelength, and derived from ray tracing simulations.  For
+        # details, see $DESIMODEL/doc/nb/DESI-0347_Throughput.ipynb.
+        path: throughput/DESI-0347_offset.ecsv
+        # The ECSV format is not auto-detected so we specify it explicitly.
+        format: ascii.ecsv
     cameras:
         b:
             constants:

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -119,6 +119,12 @@ instrument:
                 radial_scale: { index: 6, unit: um/arcsec }
                 azimuthal_scale: { index: 7, unit: um/arcsec }
     fiberloss:
+        # Method for calculating fiberloss fractions.
+        # Either galsim or table.
+        method: galsim
+        # Number of wavelengths where fiberloss should be calculated
+        # and interpolated.
+        ngrid: 11
         table:
             format: ascii
             paths:

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -121,7 +121,7 @@ instrument:
     fiberloss:
         # Method for calculating fiberloss fractions.
         # Either galsim or table.
-        method: galsim
+        method: table
         # Number of wavelengths where fiberloss should be calculated
         # and interpolated. Ignored unless method is galsim.
         num_wlen: 11
@@ -280,6 +280,7 @@ instrument:
 # specsim.source module.
 source:
     name: 22nd AB magnitude reference
+    # The type is only used when instrument.fiberloss.method is 'table'.
     type: qso
     table:
         format: ascii
@@ -295,8 +296,8 @@ source:
     # ignored otherwise).
     profile:
         # If the pointlike_fraction is 1, all other parameters are ignored.
-        pointlike_fraction: 0.0
-        disk_fraction: 0.5
+        pointlike_fraction: 1.0
+        disk_fraction: 0.0
         disk_shape:
             half_light_radius: 0.8 arcsec
             position_angle: 45 deg

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -127,7 +127,7 @@ instrument:
         num_wlen: 11
         # Number of pixels used to subdivide the fiber diameter for
         # numerical convolution and integration calculations with galsim.
-        num_pixels: 25
+        num_pixels: 32
         # Table of pre-tabulated fiberloss fractions vs wavelength for
         # different source types.  Ignored unless method is table.
         table:

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -125,9 +125,9 @@ instrument:
         # Number of wavelengths where fiberloss should be calculated
         # and interpolated. Ignored unless method is galsim.
         num_wlen: 11
-        # Pixel size for numerically integrating flux into the fiber.
-        # Ignored unless method is galsim.
-        pixel_size: 0.05 arcsec
+        # Number of pixels used to subdivide the fiber diameter for
+        # numerical convolution and integration calculations with galsim.
+        num_pixels: 25
         # Table of pre-tabulated fiberloss fractions vs wavelength for
         # different source types.  Ignored unless method is table.
         table:

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -138,6 +138,13 @@ instrument:
             columns:
                 wavelength: { index: 0, unit: Angstrom }
                 fiber_acceptance: { index: 1 }
+    blur:
+        # Read RMS blur values tabulated as a function of field angle and
+        # wavelength, and derived from ray tracing simulations.  For details,
+        # see $DESIMODEL/doc/nb/DESI-0347_Throughput.ipynb.
+        path: throughput/DESI-0347_blur.ecsv
+        # The ECSV format is not auto-detected so we specify it explicitly.
+        format: ascii.ecsv
     cameras:
         b:
             constants:

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -251,6 +251,18 @@ source:
                 index: 1
                 # Note the factor of 1e-17 in the units!
                 unit: 1e-17 erg / (Angstrom cm2 s)
+    # Transverse profile of the source on the sky, used to calculate the
+    # fiberloss fraction.
+    profile:
+        disk_fraction: 0.5
+        disk_shape:
+            half_light_radius: 0.8 arcsec
+            position_angle: 45 deg
+            minor_major_axis_ratio: 0.5
+        bulge_shape:
+            half_light_radius: 1.2 arcsec
+            position_angle: 60 deg
+            minor_major_axis_ratio: 0.8
     # Location of the source on the sky. A source will not be visible if
     # it lies out the observation field of view.
     location:

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -314,8 +314,8 @@ source:
         constants:
             # Comment out these lines to have (x,y) and the airmass
             # calculated automatically for this source and observation.
-            focal_x: 0 mm
-            focal_y: 100 mm
+            focal_x: -70.7 mm
+            focal_y: +70.7 mm
         # Sky coordinates are optional (and ignored) when focal-plane (x,y)
         # are specified.
         sky: { coordinates: 0h 0d, frame: icrs }

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -49,6 +49,14 @@ atmosphere:
                 bright: spectra/spec-sky-bright.dat
         # Specify the current condition.
         condition: dark
+    # Atmospheric seeing.
+    seeing:
+        # The seeing is assumed to scale with wavelength as
+        # fwhm(wlen) = fwhm_ref * (wlen / wlen_ref) ** -0.2
+        fwhm_ref: 1.1 arcsec
+        wlen_ref: 6355 Angstrom
+        # The seeing PSF is modeled as a Moffat profile.
+        moffat_beta: 3.5
     # Surface brightness of scattered moonlight.
     moon:
         # Un-normalized spectrum of scattered moonlight.

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -157,6 +157,12 @@ instrument:
         path: throughput/DESI-0347_offset.ecsv
         # The ECSV format is not auto-detected so we specify it explicitly.
         format: ascii.ecsv
+        # Read random achromatic centroid offsets from a FITS file.
+        # Uncomment any one of these lines to select a different random set.
+        # No random offsets are applied if all lines are commented out.
+        random: throughput/DESI-0347_random_offset_1.fits
+        #random: throughput/DESI-0347_random_offset_2.fits
+        #random: throughput/DESI-0347_random_offset_3.fits
     cameras:
         b:
             constants:

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -123,8 +123,13 @@ instrument:
         # Either galsim or table.
         method: galsim
         # Number of wavelengths where fiberloss should be calculated
-        # and interpolated.
+        # and interpolated. Ignored unless method is galsim.
         ngrid: 11
+        # Pixel size for numerically integrating flux into the fiber.
+        # Ignored unless method is galsim.
+        pixel_size: 0.05 arcsec
+        # Table of pre-tabulated fiberloss fractions vs wavelength for
+        # different source types.  Ignored unless method is table.
         table:
             format: ascii
             paths:

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -77,9 +77,12 @@ instrument:
         # Method for calculating fiberloss fractions.
         # Either galsim or table.
         method: table
+        # Table of pre-tabulated fiberloss fractions vs wavelength for
+        # different source types.  Ignored unless method is table.
         table:
             format: ascii
             paths:
+                # Each path corresponds to a different source type.
                 qso: test/test_fiberloss.ecsv
             columns:
                 wavelength: { name: wavelength }

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -74,6 +74,9 @@ instrument:
         constants:
             value: 70.4 um / arcsec
     fiberloss:
+        # Method for calculating fiberloss fractions.
+        # Either galsim or table.
+        method: table
         table:
             format: ascii
             paths:

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -84,6 +84,8 @@ instrument:
             columns:
                 wavelength: { name: wavelength }
                 fiber_acceptance: { name: fiberloss }
+    blur:
+        value: 10 micron
     cameras:
         r:
             constants:

--- a/specsim/data/config/test.yaml
+++ b/specsim/data/config/test.yaml
@@ -85,7 +85,13 @@ instrument:
                 wavelength: { name: wavelength }
                 fiber_acceptance: { name: fiberloss }
     blur:
+        # RMS blur of the instrument optics.  Use the path keyword instead
+        # to read values tabulated in wavelength and field angle.
         value: 10 micron
+    offset:
+        # Radial centroid offset of the instrument optics. Use the path keyword
+        # instead to read values tabulated in wavelength and field angle.
+        value: 0 micron
     cameras:
         r:
             constants:

--- a/specsim/driver.py
+++ b/specsim/driver.py
@@ -5,10 +5,10 @@ from __future__ import print_function, division
 
 import os.path
 import warnings
+import argparse
 
 import numpy as np
 
-from astropy.utils.compat import argparse
 import astropy.units as u
 import astropy.io.fits as fits
 

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -18,7 +18,7 @@ def calculate_fiber_acceptance_fraction(
     """
     """
     # Use pre-tabulated fiberloss vs wavelength when available.
-    if instrument.fiberloss_ngrid == 0:
+    if instrument.fiberloss_num_wlen == 0:
         return instrument.fiber_acceptance_dict[source.type_name]
 
     # Galsim is required to calculate fiberloss fractions on the fly.
@@ -28,7 +28,7 @@ def calculate_fiber_acceptance_fraction(
     # calculated.
     wlen_unit = wavelength.unit
     wlen_grid = np.linspace(wavelength.data[0], wavelength.data[-1],
-                            instrument.fiberloss_ngrid) * wlen_unit
+                            instrument.fiberloss_num_wlen) * wlen_unit
 
     # Calculate the field angle from the focal-plane (x,y).
     focal_r = np.sqrt(focal_x ** 2 + focal_y ** 2)

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -18,7 +18,49 @@ import astropy.table
 def calculate_fiber_acceptance_fraction(
     focal_x, focal_y, wavelength, source, atmosphere, instrument,
     oversampling = 16, save_images=None, save_table=None):
-    """
+    """Calculate the fiber acceptance fraction.
+
+    The behavior of this function is customized by the instrument.fiberloss
+    configuration parameters. When instrument.fiberloss.method == 'table',
+    pre-tabulated values are returned using source.type as the key and
+    all other parameters to this function are ignored.
+
+    When instrument.fiberloss.method == 'galsim', fiberloss is calculated
+    on the fly using the GalSim package to model the PSF components and
+    source profile and perform the convolutions.
+
+    Parameters
+    ----------
+    focal_x : :class:`astropy.units.Quantity`
+        X coordinate of the fiber center in the focal plane with length units.
+    focal_y : :class:`astropy.units.Quantity`
+        Y coordinate of the fiber center in the focal plane with length units.
+    wavelength : :class:`astropy.table.Column`
+        Array of simulation wavelengths where the fiber acceptance fraction
+        should be tabulated.
+    source : :class:`specsim.source.Source`
+        Source model to use for the calculation.
+    atmosphere : :class:`specsim.atmosphere.Atmosphere`
+        Atmosphere model to use for the calculation.
+    instrument : :class:`specsim.instrument.Instrument`
+        Instrument model to use for the calculation.
+    oversampling : int
+        Oversampling factor to use for anti-aliasing the fiber aperture.
+    save_images : str or None
+        Write a multi-extension FITS file with this name containing images of
+        the atmospheric and instrument PSFs as a function of wavelength, as
+        well as the source profile.
+    save_table : str or None
+        Write a table of calculated values to a file with this name.  The
+        extension determines the file format, and .ecsv is recommended.
+        The saved file can then be used as a pre-tabulated input with
+        instrument.fiberloss.method = 'table'.
+
+    Returns
+    -------
+    numpy array
+        Array of fiber acceptance fractions (dimensionless) at each of the
+        input wavelengths.
     """
     # Use pre-tabulated fiberloss vs wavelength when available.
     if instrument.fiberloss_num_wlen == 0:

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -9,8 +9,8 @@ from __future__ import print_function, division
 import astropy.units as u
 
 
-def calculate_fiber_acceptance_fraction(wavelength, source, atmosphere,
-                                        instrument, observation):
+def calculate_fiber_acceptance_fraction(focal_x, focal_y, wavelength,
+                                        source, atmosphere, instrument):
     """
     """
     # Use tabulated when available.
@@ -24,6 +24,17 @@ def calculate_fiber_acceptance_fraction(wavelength, source, atmosphere,
         instrument.fiberloss_ngrid))
     wlen_grid = np.linspace(wavelength[0], wavelength[-1],
                        instrument.fiberloss_ngrid)
+
+    # Calculate the field angle from the focal-plane (x,y).
+    focal_r = np.sqrt(x ** 2 + y ** 2)
+    angle = instrument.field_radius_to_angle(focal_r)
+
+    # Create the instrument blur PSF at each wavelength for this focal-plane
+    # position.
+    blur_psf = []
+    for wlen in wlen_grid:
+        blur_psf.append(galsim.Gaussian(
+            sigma=instrument.get_blur_rms(wlen, angle)))
 
     # Create the atmospheric seeing model at each wavelength.
     seeing_psf = []

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -12,6 +12,7 @@ import numpy.lib.stride_tricks
 import astropy.units as u
 import astropy.io.fits
 import astropy.wcs
+import astropy.table
 
 
 def calculate_fiber_acceptance_fraction(
@@ -182,11 +183,12 @@ def calculate_fiber_acceptance_fraction(
             name='Wavelength', data=wlen_grid.value, unit=wlen_grid.unit,
             description='Observed wavelength'))
         table.add_column(astropy.table.Column(
-            name='Fiberloss', data=fiberloss_grid,
+            name='FiberAcceptance', data=fiberloss_grid,
             description='Fiber acceptance fraction'))
         args = {}
         if save_table.endswith('.ecsv'):
             args['format'] = 'ascii.ecsv'
         table.write(save_table, **args)
 
-    return instrument.fiber_acceptance_dict[source.type_name]
+    # Interpolate (linearly) to the simulation wavelength grid.
+    return np.interp(wavelength.data, wlen_grid.value, fiberloss_grid)

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -9,8 +9,8 @@ from __future__ import print_function, division
 import astropy.units as u
 
 
-def calculate_fiber_acceptance_fraction(source, atmosphere, instrument,
-                                        observation):
+def calculate_fiber_acceptance_fraction(wavelength, source, atmosphere,
+                                        instrument, observation):
     """
     """
     # Use tabulated when available.
@@ -22,6 +22,15 @@ def calculate_fiber_acceptance_fraction(source, atmosphere, instrument,
 
     print('Will tabulate fiberloss at {0} wavelengths...'.format(
         instrument.fiberloss_ngrid))
+    wlen_grid = np.linspace(wavelength[0], wavelength[-1],
+                       instrument.fiberloss_ngrid)
+
+    # Create the atmospheric seeing model at each wavelength.
+    seeing_psf = []
+    for wlen in wlen_grid:
+        seeing_psf.append(galsim.Moffat(
+            fwhm=atmosphere.get_seeing_fwhm(wlen).to(u.arcsec).value,
+            beta=atmosphere.seeing['moffat_beta']))
 
     # Create the source model, which we assume to be achromatic.
     source_components = []

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -137,9 +137,9 @@ def calculate_fiber_acceptance_fraction(
             blur_psf[i], seeing_psf[i], source_model], gsparams=gsparams)
         # TODO: compare method='no_pixel' and 'auto' for accuracy and speed.
         dx, dy = offsets[i]
-        draw_args = dict(
-            image=image, method='auto', offset=(dx / scale, dy / scale))
-        convolved.drawImage(**draw_args)
+        offset = (dx / scale, dy / scale)
+        draw_args = dict(image=image, method='auto')
+        convolved.drawImage(offset=offset, **draw_args)
         fraction = np.sum(image.array * aperture)
         print('fiberloss:', wlen, dx, dy, fraction)
         if save:
@@ -150,17 +150,18 @@ def calculate_fiber_acceptance_fraction(
                 data=image.array.copy(), header=header))
             # The component models are only rendered individually if we
             # need to save them.
-            blur_psf[i].drawImage(**draw_args)
+            blur_psf[i].drawImage(offset=offset, **draw_args)
             header['COMMENT'] = 'Instrument blur model'
             hdu_list.append(astropy.io.fits.ImageHDU(
                 data=image.array.copy(), header=header))
+            # Render the seeing without the instrumental offset.
             seeing_psf[i].drawImage(**draw_args)
             header['COMMENT'] = 'Atmospheric seeing model'
             hdu_list.append(astropy.io.fits.ImageHDU(
                 data=image.array.copy(), header=header))
 
     if save:
-        del draw_args['offset']
+        # Render the source model without the instrumental offset.
         source_model.drawImage(**draw_args)
         header['COMMENT'] = 'Source model'
         hdu_list.append(astropy.io.fits.ImageHDU(

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -6,9 +6,36 @@ illuminating a fiber and the on-sky aperture of the fiber.
 """
 from __future__ import print_function, division
 
+import astropy.units as u
+
 
 def calculate_fiber_acceptance_fraction(source, atmosphere, instrument,
                                         observation):
     """
     """
+    import galsim
+
+    # Create the source model, which we assume to be achromatic.
+    source_components = []
+    if source.disk_fraction > 0:
+        hlr = source.disk_shape.half_light_radius.to(u.arcsec).value
+        q = source.disk_shape.minor_major_axis_ratio
+        beta = source.disk_shape.position_angle.to(u.deg).value
+        disk_model = galsim.Exponential(
+            flux=source.disk_fraction, half_light_radius=hlr).shear(
+                q=q, beta=beta * galsim.degrees)
+    if source.disk_fraction < 1:
+        hlr = source.bulge_shape.half_light_radius.to(u.arcsec).value
+        q = source.bulge_shape.minor_major_axis_ratio
+        beta = source.bulge_shape.position_angle.to(u.deg).value
+        bulge_model = galsim.DeVaucouleurs(
+            flux=source.disk_fraction, half_light_radius=hlr).shear(
+                q=q, beta=beta * galsim.degrees)
+    if source.disk_fraction == 0:
+        source_model = bulge_model
+    elif source.disk_fraction == 1:
+        source_model = disk_model
+    else:
+        source_model = disk_model + bulge_model
+
     return instrument.get_fiber_acceptance(source)

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -82,7 +82,7 @@ def calculate_fiber_acceptance_fraction(
             flux=source.disk_fraction, half_light_radius=hlr).shear(
                 q=q, beta=beta * galsim.degrees))
     bulge_fraction = 1 - (source.pointlike_fraction + source.disk_fraction)
-    if bulge_fraction > 1:
+    if bulge_fraction > 0:
         hlr = source.bulge_shape.half_light_radius.to(u.arcsec).value
         q = source.bulge_shape.minor_major_axis_ratio
         beta = source.bulge_shape.position_angle.to(u.deg).value

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -1,0 +1,13 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Calculate fiberloss fractions.
+
+Fiberloss fractions are computed as the overlap between the light profile
+illuminating a fiber and the on-sky aperture of the fiber.
+"""
+from __future__ import print_function, division
+
+
+def calculate_fiberloss_fraction():
+    """
+    """
+    pass

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -32,15 +32,21 @@ def calculate_fiber_acceptance_fraction(focal_x, focal_y, wavelength,
     focal_r = np.sqrt(focal_x ** 2 + focal_y ** 2)
     angle = instrument.field_radius_to_angle(focal_r)
 
-    # Create the instrument blur PSF at each wavelength for this focal-plane
-    # position.
+    # Create the instrument blur PSF and lookup the centroid offset at each
+    # wavelength for this focal-plane position.
     blur_psf = []
+    offsets = []
     for wlen in wlen_grid:
         blur_rms = instrument.get_blur_rms(wlen, angle)
         # Convert to an angular size on the sky ignoring any asymmetry that
         # might be introduced by different radial and azimuthal plate scales.
-        blur_rms /= instrument.radial_scale(focal_r)
+        rscale = instrument.radial_scale(focal_r)
+        blur_rms /= rscale
         blur_psf.append(galsim.Gaussian(sigma=blur_rms.to(u.arcsec).value))
+        offset = instrument.get_centroid_offset(wlen, angle)
+        # Convert to an angular offset on the sky.
+        offset /= rscale
+        offsets.append(offset.to(u.arcsec).value)
 
     # Create the atmospheric seeing model at each wavelength.
     seeing_psf = []

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -7,7 +7,8 @@ illuminating a fiber and the on-sky aperture of the fiber.
 from __future__ import print_function, division
 
 
-def calculate_fiberloss_fraction():
+def calculate_fiber_acceptance_fraction(source, atmosphere, instrument,
+                                        observation):
     """
     """
-    pass
+    return instrument.get_fiber_acceptance(source)

--- a/specsim/fiberloss.py
+++ b/specsim/fiberloss.py
@@ -13,7 +13,15 @@ def calculate_fiber_acceptance_fraction(source, atmosphere, instrument,
                                         observation):
     """
     """
+    # Use tabulated when available.
+    if instrument.fiber_acceptance_dict:
+        return instrument.fiber_acceptance_dict[source.type_name]
+
+    # Galsim is required to calculate fiberloss fractions on the fly.
     import galsim
+
+    print('Will tabulate fiberloss at {0} wavelengths...'.format(
+        instrument.fiberloss_ngrid))
 
     # Create the source model, which we assume to be achromatic.
     source_components = []
@@ -38,4 +46,4 @@ def calculate_fiber_acceptance_fraction(source, atmosphere, instrument,
     else:
         source_model = disk_model + bulge_model
 
-    return instrument.get_fiber_acceptance(source)
+    return instrument.fiber_acceptance_dict[source.type_name]

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -530,6 +530,15 @@ def initialize(config):
     else:
         offset_function = config.load_table2d(
             config.instrument.offset, 'wavelength', 'r=')
+        if hasattr(config.instrument.offset, 'random'):
+            if config.verbose:
+                print('Reading random centroid offsets from',
+                      config.instrument.offset.random)
+            hdus = config.load_fits(
+                config.instrument.offset.random, memmap=False)
+            random_dx = hdus['XOFFSET'].data
+            random_dy = hdus['YOFFSET'].data
+            hdus.close()
 
     instrument = Instrument(
         name, config.wavelength, fiber_acceptance_dict, fiberloss_num_wlen,

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -47,7 +47,7 @@ class Instrument(object):
     fiber_acceptance_dict : dict or None
         Dictionary of fiber acceptance fractions tabulated for different
         source models, with keys corresponding to source model names.
-    fiberloss_ngrid : int
+    fiberloss_num_wlen : int
         Number of wavelengths where the fiberloss fraction should be tabulated
         for interpolation.  Will be zero when fiber_acceptance_dict is set.
     fiberloss_pixel_size : astropy.units.Quantity
@@ -85,14 +85,14 @@ class Instrument(object):
         (sagittal) direction (with appropriate units) as a function of
         focal-plane distance (with length units) from the boresight.
     """
-    def __init__(self, name, wavelength, fiber_acceptance_dict, fiberloss_ngrid,
+    def __init__(self, name, wavelength, fiber_acceptance_dict, fiberloss_num_wlen,
                  fiberloss_pixel_size, blur_function, offset_function, cameras,
                  primary_mirror_diameter, obscuration_diameter, support_width,
                  fiber_diameter, field_radius, radial_scale, azimuthal_scale):
         self.name = name
         self._wavelength = wavelength
         self.fiber_acceptance_dict = fiber_acceptance_dict
-        self.fiberloss_ngrid = fiberloss_ngrid
+        self.fiberloss_num_wlen = fiberloss_num_wlen
         self.fiberloss_pixel_size = fiberloss_pixel_size
         self._blur_function = blur_function
         self._offset_function = offset_function
@@ -508,11 +508,11 @@ def initialize(config):
     fiber_acceptance_dict = config.load_table(
         config.instrument.fiberloss, 'fiber_acceptance', as_dict=True)
     if config.instrument.fiberloss.method == 'table':
-        fiberloss_ngrid = 0
+        fiberloss_num_wlen = 0
         fiberloss_pixel_size = 0 * u.arcsec
     else:
         #fiber_acceptance_dict = None
-        fiberloss_ngrid = config.instrument.fiberloss.ngrid
+        fiberloss_num_wlen = config.instrument.fiberloss.num_wlen
         fiberloss_pixel_size = specsim.config.parse_quantity(
             config.instrument.fiberloss.pixel_size)
 
@@ -533,7 +533,7 @@ def initialize(config):
             config.instrument.offset, 'wavelength', 'r=')
 
     instrument = Instrument(
-        name, config.wavelength, fiber_acceptance_dict, fiberloss_ngrid,
+        name, config.wavelength, fiber_acceptance_dict, fiberloss_num_wlen,
         fiberloss_pixel_size, blur_function, offset_function,
         initialized_cameras,
         constants['primary_mirror_diameter'], constants['obscuration_diameter'],

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -41,7 +41,7 @@ class Instrument(object):
     ----------
     name : str
         Descriptive name of this instrument.
-    wavelength : nastropy.units.Quantity
+    wavelength : astropy.units.Quantity
         Array of wavelength bin centers where the instrument response is
         calculated, with units.
     fiber_acceptance_dict : dict or None
@@ -50,6 +50,10 @@ class Instrument(object):
     fiberloss_ngrid : int
         Number of wavelengths where the fiberloss fraction should be tabulated
         for interpolation.  Will be zero when fiber_acceptance_dict is set.
+    fiberloss_pixel_size : astropy.units.Quantity
+        Size of pixels to use for numerically integrating flux entering the
+        fiber to calculate fiberloss fractions as a function of wavelength.
+        Must have on-sky angular units.
     blur_function : callable
         Function of field angle and wavelength that returns the corresponding
         RMS blur in length units (e.g., microns).
@@ -82,13 +86,14 @@ class Instrument(object):
         focal-plane distance (with length units) from the boresight.
     """
     def __init__(self, name, wavelength, fiber_acceptance_dict, fiberloss_ngrid,
-                 blur_function, offset_function, cameras,
+                 fiberloss_pixel_size, blur_function, offset_function, cameras,
                  primary_mirror_diameter, obscuration_diameter, support_width,
                  fiber_diameter, field_radius, radial_scale, azimuthal_scale):
         self.name = name
         self._wavelength = wavelength
         self.fiber_acceptance_dict = fiber_acceptance_dict
         self.fiberloss_ngrid = fiberloss_ngrid
+        self.fiberloss_pixel_size = fiberloss_pixel_size
         self._blur_function = blur_function
         self._offset_function = offset_function
         self.cameras = cameras
@@ -504,9 +509,12 @@ def initialize(config):
         config.instrument.fiberloss, 'fiber_acceptance', as_dict=True)
     if config.instrument.fiberloss.method == 'table':
         fiberloss_ngrid = 0
+        fiberloss_pixel_size = 0 * u.arcsec
     else:
         #fiber_acceptance_dict = None
         fiberloss_ngrid = config.instrument.fiberloss.ngrid
+        fiberloss_pixel_size = specsim.config.parse_quantity(
+            config.instrument.fiberloss.pixel_size)
 
     blur_value = getattr(config.instrument.blur, 'value', None)
     if blur_value:
@@ -526,7 +534,8 @@ def initialize(config):
 
     instrument = Instrument(
         name, config.wavelength, fiber_acceptance_dict, fiberloss_ngrid,
-        blur_function, offset_function, initialized_cameras,
+        fiberloss_pixel_size, blur_function, offset_function,
+        initialized_cameras,
         constants['primary_mirror_diameter'], constants['obscuration_diameter'],
         constants['support_width'], constants['fiber_diameter'],
         constants['field_radius'], radial_scale, azimuthal_scale)

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -532,7 +532,7 @@ def initialize(config):
             config.instrument.offset, 'wavelength', 'r=')
         if hasattr(config.instrument.offset, 'random'):
             random_interpolators = config.load_fits2d(
-                config.instrument.offset.random,
+                config.instrument.offset.random, xy_unit=u.deg,
                 random_x='XOFFSET', random_y='YOFFSET')
 
     instrument = Instrument(

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -531,14 +531,9 @@ def initialize(config):
         offset_function = config.load_table2d(
             config.instrument.offset, 'wavelength', 'r=')
         if hasattr(config.instrument.offset, 'random'):
-            if config.verbose:
-                print('Reading random centroid offsets from',
-                      config.instrument.offset.random)
-            hdus = config.load_fits(
-                config.instrument.offset.random, memmap=False)
-            random_dx = hdus['XOFFSET'].data
-            random_dy = hdus['YOFFSET'].data
-            hdus.close()
+            random_interpolators = config.load_fits2d(
+                config.instrument.offset.random,
+                random_x='XOFFSET', random_y='YOFFSET')
 
     instrument = Instrument(
         name, config.wavelength, fiber_acceptance_dict, fiberloss_num_wlen,

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -211,6 +211,25 @@ class Instrument(object):
             angle.to(self._angle_unit)) * self._radius_unit
 
 
+    def get_blur_rms(self, wavelength, angle):
+        """Calculate the instrument PSF blur at the specified field angle.
+
+        Parameters
+        ----------
+        wavelength : astropy.units.Quantity
+            Wavelength where the blur should be calculated.
+        angle : astropy.units.Quantity
+            Angular separation from the field center.
+
+        Returns
+        -------
+        astropy.units.Quantity
+            RMS blur of the instrument at this wavelength and field radius
+            in angular units.
+        """
+        return 1. * u.micron
+
+
     def plot_field_distortion(self):
         """Plot focal plane distortions over the field of view.
 

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -474,6 +474,8 @@ def initialize(config):
         print('Field of view diameter: {0:.1f} = {1:.2f}.'
               .format(2 * instrument.field_radius.to(u.mm),
                       2 * instrument.field_angle.to(u.deg)))
-        print('Source types: {0}.'.format(instrument.source_types))
+        if instrument.fiber_acceptance_dict:
+            print('Source types: {0}.'
+                  .format(instrument.fiber_acceptance_dict.keys()))
 
     return instrument

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -546,8 +546,6 @@ def initialize(config):
             random_interpolators = config.load_fits2d(
                 config.instrument.offset.random, xy_unit=u.deg,
                 random_dx='XOFFSET', random_dy='YOFFSET')
-            print('dx',random_interpolators['random_dx'](0*u.deg, 0*u.deg),
-                  'dy',random_interpolators['random_dy'](0*u.deg, 0*u.deg))
         else:
             random_interpolators = dict(
                 random_dx=lambda angle_x, angle_y: 0 * u.um,

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -479,6 +479,10 @@ def initialize(config):
         #fiber_acceptance_dict = None
         fiberloss_ngrid = config.instrument.fiberloss.ngrid
 
+    blur_interpolator = config.load_table2d(
+        config.instrument.blur, 'wavelength', 'r=')
+    print('blur test', blur_interpolator(0.45 * u.deg, 5000 * u.Angstrom))
+
     instrument = Instrument(
         name, config.wavelength, fiber_acceptance_dict, fiberloss_ngrid,
         initialized_cameras,

--- a/specsim/observation.py
+++ b/specsim/observation.py
@@ -6,9 +6,8 @@ a simulator and then accessible via its ``observation`` attribute, for example:
 
     >>> import specsim.simulator
     >>> simulator = specsim.simulator.Simulator('test')
-    >>> print(simulator.observation.pointing)
-    <SkyCoord (ICRS): (ra, dec) in deg
-        (0.0, 0.0)>
+    >>> print(simulator.observation.exposure_time)
+    1000.0 s
 
 After initialization, all aspects of an observation can be modified at runtime.
 """

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -208,7 +208,7 @@ class Simulator(object):
             specsim.fiberloss.calculate_fiber_acceptance_fraction(
                 self.focal_x, self.focal_y, wavelength, self.source,
                 self.atmosphere, self.instrument,
-                save_images='fiberloss.fits')
+                save_images='fiberloss.fits', save_table='fiberloss.ecsv')
 
         # Calculate the source flux entering a fiber.
         source_fiber_flux[:] = (

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -207,7 +207,7 @@ class Simulator(object):
         fiber_acceptance_fraction =\
             specsim.fiberloss.calculate_fiber_acceptance_fraction(
                 self.focal_x, self.focal_y, wavelength, self.source,
-                self.atmosphere, self.instrument)
+                self.atmosphere, self.instrument, save='fiberloss.fits')
 
         # Calculate the source flux entering a fiber.
         source_fiber_flux[:] = (

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -206,8 +206,8 @@ class Simulator(object):
         # Calculate fraction of source illumination entering the fiber.
         fiber_acceptance_fraction =\
             specsim.fiberloss.calculate_fiber_acceptance_fraction(
-                wavelength, self.source, self.atmosphere, self.instrument,
-                self.observation)
+                self.focal_x, self.focal_y, wavelength, self.source,
+                self.atmosphere, self.instrument)
 
         # Calculate the source flux entering a fiber.
         source_fiber_flux[:] = (

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -206,7 +206,8 @@ class Simulator(object):
         # Calculate fraction of source illumination entering the fiber.
         fiber_acceptance_fraction =\
             specsim.fiberloss.calculate_fiber_acceptance_fraction(
-                self.source, self.atmosphere, self.instrument, self.observation)
+                wavelength, self.source, self.atmosphere, self.instrument,
+                self.observation)
 
         # Calculate the source flux entering a fiber.
         source_fiber_flux[:] = (

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -207,7 +207,8 @@ class Simulator(object):
         fiber_acceptance_fraction =\
             specsim.fiberloss.calculate_fiber_acceptance_fraction(
                 self.focal_x, self.focal_y, wavelength, self.source,
-                self.atmosphere, self.instrument, save='fiberloss.fits')
+                self.atmosphere, self.instrument,
+                save_images='fiberloss.fits')
 
         # Calculate the source flux entering a fiber.
         source_fiber_flux[:] = (

--- a/specsim/source.py
+++ b/specsim/source.py
@@ -21,6 +21,8 @@ import astropy.units as u
 
 import speclite.filters
 
+import specsim.config
+
 
 class Source(object):
     """Source model used for simulation.
@@ -279,14 +281,38 @@ class Source(object):
 
 
 class Profile(object):
+    """Transverse profile of a single Sersic component of a galaxy.
 
+    If any parameters are strings, they will be converted and validated.
+
+    Parameters
+    ----------
+    half_light_radius : str or astropy.units.Quantity
+        Half-light radius of this component with angular units.
+    minor_major_axis_ratio : float
+        Ratio of the minor to major ellipse axes q = a/b, which must
+        be 0 < q <= 1.
+    position_angle : str or astropy.units.Quantity
+        Position angle of this component's major axis with angular units.
+        Angles are measured counter-clockwise from the +x axis of the focal
+        plane coordinate system.
+    sersic_index : float
+        Sersic index of this component, which must be > 0.
+    """
     def __init__(self, half_light_radius, minor_major_axis_ratio,
                  position_angle, sersic_index):
-
-        self.half_light_radius = half_light_radius
-        self.minor_major_axis_ratio = minor_major_axis_ratio
-        self.position_angle = position_angle
-        self.sersic_index = sersic_index
+        """Validate and save Sersic component parameters.
+        """
+        self.half_light_radius = specsim.config.parse_quantity(
+            half_light_radius, u.arcsec)
+        self.minor_major_axis_ratio = float(minor_major_axis_ratio)
+        if self.minor_major_axis_ratio <= 0 or self.minor_major_axis_ratio > 1:
+            raise ValueError('Expected minor/major axis ratio in (0,1].')
+        self.position_angle = specsim.config.parse_quantity(
+            position_angle, u.deg)
+        self.sersic_index = float(sersic_index)
+        if self.sersic_index <= 0:
+            raise ValueError('Expected Sersic index > 0.')
 
 
 def initialize(config):

--- a/specsim/source.py
+++ b/specsim/source.py
@@ -263,6 +263,17 @@ class Source(object):
         return self._flux_out
 
 
+class Profile(object):
+
+    def __init__(self, half_light_radius, minor_major_axis_ratio,
+                 position_angle, sersic_index):
+
+        self.half_light_radius = half_light_radius
+        self.minor_major_axis_ratio = minor_major_axis_ratio
+        self.position_angle = position_angle
+        self.sersic_index = sersic_index
+
+
 def initialize(config):
     """Initialize the source model from configuration parameters.
 
@@ -289,6 +300,19 @@ def initialize(config):
     # Sky position is optional (and ignored) when x,y are specified.
     if hasattr(config.source.location, 'sky'):
         sky_position = config.get_sky(config.source.location)
+    # Get the source profile on the sky.
+    if hasattr(config.source, 'profile'):
+        fraction = config.source.profile.disk_fraction
+        disk = Profile(
+            config.source.profile.disk_shape.half_light_radius,
+            config.source.profile.disk_shape.minor_major_axis_ratio,
+            config.source.profile.disk_shape.position_angle, sersic_index=1)
+        bulge = Profile(
+            config.source.profile.bulge_shape.half_light_radius,
+            config.source.profile.bulge_shape.minor_major_axis_ratio,
+            config.source.profile.bulge_shape.position_angle, sersic_index=4)
+    else:
+        fraction, disk, bulge = 0, None, None
     # Create a new Source object.
     source = Source(
         config.source.name, config.source.type, config.wavelength,

--- a/specsim/tests/test_fiberloss.py
+++ b/specsim/tests/test_fiberloss.py
@@ -1,0 +1,10 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import print_function, division
+
+from astropy.tests.helper import pytest
+
+from ..fiberloss import *
+
+
+def test_fiberloss():
+    calculate_fiberloss_fraction()

--- a/specsim/tests/test_fiberloss.py
+++ b/specsim/tests/test_fiberloss.py
@@ -3,8 +3,12 @@ from __future__ import print_function, division
 
 from astropy.tests.helper import pytest
 
+import specsim.simulator
+
 from ..fiberloss import *
 
 
 def test_fiberloss():
-    calculate_fiberloss_fraction()
+    sim = specsim.simulator.Simulator('test')
+    fa = calculate_fiber_acceptance_fraction(
+        sim.source, sim.atmosphere, sim.instrument, sim.observation)

--- a/specsim/tests/test_fiberloss.py
+++ b/specsim/tests/test_fiberloss.py
@@ -11,4 +11,5 @@ from ..fiberloss import *
 def test_fiberloss():
     sim = specsim.simulator.Simulator('test')
     fa = calculate_fiber_acceptance_fraction(
-        sim.source, sim.atmosphere, sim.instrument, sim.observation)
+        0. * u.mm, 0. * u.mm, 6000 * u.Angstrom,
+        sim.source, sim.atmosphere, sim.instrument)

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -181,6 +181,9 @@ def test_alt_warn_pressure_array():
     with pytest.raises(UserWarning):
         altaz_to_sky(alt, 0*u.deg, obs_model)
     alt = np.array([alt0 - 1, alt0 + 1]) * u.deg
+    pressure = np.array([800., 0.]) * u.kPa
+    obs_model = create_observing_model(where=where, when=when, wavelength=wlen,
+                                       pressure=pressure[:, np.newaxis])
     with pytest.raises(UserWarning):
         print(altaz_to_sky(alt[:, np.newaxis], 0*u.deg, obs_model).shape)
 


### PR DESCRIPTION
This is not ready to merge yet but is getting close.  Here is the final checklist:
- [x] Add support for point-like sources.
- [x] Anti-alias fiber aperture.
- [x] Read and use file of optional achromatic centroid offsets.
- [x] Add option to save pre-tabulated fiberloss for later use w/o galsim.
- [x] Review documentation of new features.
- [ ] Compare with fiberloss files in desimodel.
- [ ] Optimize numerical parameters num_wlen, num_pixels.
- [ ] Add some unit tests of new features.

The goal of this PR is to obtain correct results at the required level of realism.  Optimizations for efficient calculation of a large number (~5K) of sources distributed over the focal plane in a single exposure are not considered here.
