### PR TITLE
Minor astropy template updates

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,11 +1,10 @@
-name: package-template
+name: specsim
 
 channels:
     - astropy
 
 dependencies:
     - astropy
-    - Cython
     - matplotlib
     - numpy
 #   - pip:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,7 @@ release = package.__version__
 # Please update these texts to match the name of your package.
 html_theme_options = {
     'logotext1': 'specsim',  # white,  semi-bold
-    'logotext2': '-template',  # orange, light
+    'logotext2': '',  # orange, light
     'logotext3': ':docs'   # white,  light
     }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ license = BSD
 url = https://github.com/desihub/specsim
 edit_on_github = True
 github_project = desihub/specsim
-install_requires = astropy
+install_requires = astropy scipy pyyaml speclite
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
 version = 0.8.dev
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,17 +3,37 @@ source-dir = docs
 build-dir = docs/_build
 all_files = 1
 
+[build_docs]
+source-dir = docs
+build-dir = docs/_build
+all_files = 1
+
 [upload_docs]
 upload-dir = docs/_build/html
 show-response = 1
 
-[tool:pytest]
+[pytest]
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled
 
 [ah_bootstrap]
 auto_use = True
+
+[pep8]
+# E101 - mix of tabs and spaces
+# W191 - use of tabs
+# W291 - trailing whitespace
+# W292 - no newline at end of file
+# W293 - trailing whitespace
+# W391 - blank line at end of file
+# E111 - 4 spaces per indentation level
+# E112 - 4 spaces per indentation level
+# E113 - 4 spaces per indentation level
+# E901 - SyntaxError or IndentationError
+# E902 - IOError
+select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E901,E902
+exclude = extern,sphinx,*parsetab.py
 
 [metadata]
 package_name = specsim
@@ -25,6 +45,9 @@ license = BSD
 url = https://github.com/desihub/specsim
 edit_on_github = True
 github_project = desihub/specsim
+install_requires = astropy
+# version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
+version = 0.8.dev
 
 [entry_points]
 quickspecsim = specsim.quickspecsim:main

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 import ah_bootstrap
 from setuptools import setup
 
-#A dirty hack to get around some early import/configurations ambiguities
+# A dirty hack to get around some early import/configurations ambiguities
 if sys.version_info[0] >= 3:
     import builtins
 else:
@@ -37,17 +37,36 @@ AUTHOR_EMAIL = metadata.get('author_email', '')
 LICENSE = metadata.get('license', 'unknown')
 URL = metadata.get('url', 'http://astropy.org')
 
-# Get the long description from the package's docstring
-__import__(PACKAGENAME)
-package = sys.modules[PACKAGENAME]
-LONG_DESCRIPTION = package.__doc__
+# order of priority for long_description:
+#   (1) set in setup.cfg,
+#   (2) load LONG_DESCRIPTION.rst,
+#   (3) load README.rst,
+#   (4) package docstring
+readme_glob = 'README*'
+_cfg_long_description = metadata.get('long_description', '')
+if _cfg_long_description:
+    LONG_DESCRIPTION = _cfg_long_description
+
+elif os.path.exists('LONG_DESCRIPTION.rst'):
+    with open('LONG_DESCRIPTION.rst') as f:
+        LONG_DESCRIPTION = f.read()
+
+elif len(glob.glob(readme_glob)) > 0:
+    with open(glob.glob(readme_glob)[0]) as f:
+        LONG_DESCRIPTION = f.read()
+
+else:
+    # Get the long description from the package's docstring
+    __import__(PACKAGENAME)
+    package = sys.modules[PACKAGENAME]
+    LONG_DESCRIPTION = package.__doc__
 
 # Store the package name in a built-in variable so it's easy
 # to get from other parts of the setup infrastructure
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
-# VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.8dev'
+# VERSION should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
+VERSION = metadata.get('version', '0.0.dev')
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION
@@ -64,9 +83,9 @@ cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
 generate_version_py(PACKAGENAME, VERSION, RELEASE,
                     get_debug_option(PACKAGENAME))
 
-# Treat everything in scripts except README.rst as a script to be installed
+# Treat everything in scripts except README* as a script to be installed
 scripts = [fname for fname in glob.glob(os.path.join('scripts', '*'))
-           if os.path.basename(fname) != 'README.rst']
+           if not os.path.basename(fname).startswith('README')]
 
 
 # Get configuration information from all of the various subpackages.
@@ -108,7 +127,7 @@ setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
-      install_requires=['astropy', 'scipy', 'pyyaml', 'speclite'],
+      install_requires=metadata.get('install_requires', 'astropy').strip().split(),
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,


### PR DESCRIPTION
The `install_requires` and `version` metadata have moved from `setup.py` to `setup.cfg`.

Documentation pages on readthedocs now have the correct title: "package-template:docs" -> "specsim:docs".

I plan to merge this as soon as the travis tests pass, then tag & release v0.8.