### PR TITLE
simulators with alternate wavelength grids

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.8 (unreleased)
 ----------------
 
-- No changes yet.
+- Better support for alternate simulation wavelength grids (PR #60).
 
 0.8 (2017-03-25)
 ----------------

--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -224,14 +224,15 @@ class Camera(object):
         self._downsampling = int(round(
             self._output_pixel_size / wavelength_step))
         num_downsampled = int(
-            (self._wavelength_max - self._wavelength_min) //
-            self._output_pixel_size)
+            round((self._wavelength_max - self._wavelength_min) /
+            self._output_pixel_size))
         pixel_edges = (
             self._wavelength_min - 0.5 * wavelength_step +
             np.arange(num_downsampled + 1) * self._output_pixel_size)
         sim_edges = (
             self._wavelength[self.ccd_slice][::self._downsampling] -
              0.5 * wavelength_step)
+
         if not np.allclose(
             pixel_edges, sim_edges, rtol=0., atol=1e-6 * wavelength_step):
             raise ValueError(

--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -232,7 +232,6 @@ class Camera(object):
         sim_edges = (
             self._wavelength[self.ccd_slice][::self._downsampling] -
              0.5 * wavelength_step)
-
         if not np.allclose(
             pixel_edges, sim_edges, rtol=0., atol=1e-6 * wavelength_step):
             raise ValueError(

--- a/specsim/tests/test_simulator.py
+++ b/specsim/tests/test_simulator.py
@@ -20,6 +20,24 @@ def test_ctor():
     sim2 = Simulator('test')
     assert sim1.atmosphere.airmass == sim2.atmosphere.airmass
 
+def test_alt_wavelengths():
+    import yaml
+    import pkg_resources
+    configfile = pkg_resources.resource_filename(
+        'specsim', 'data/config/test.yaml')
+    configdata = yaml.load(open(configfile))
+
+    # Create simulator with a 0.1 Angstrom simulation grid
+    configdata['wavelength_grid']['step'] = 0.1
+    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.1 Angstrom'
+    config1 = specsim.config.Configuration(configdata)
+    sim1 = Simulator(config1)
+
+    # Update to a 0.2 Angstrom step size and repeat
+    configdata['wavelength_grid']['step'] = 0.2
+    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.2 Angstrom'
+    config2 = specsim.config.Configuration(configdata)
+    sim2 = Simulator(config2)
 
 def test_end_to_end():
     sim = Simulator('test')

--- a/specsim/tests/test_simulator.py
+++ b/specsim/tests/test_simulator.py
@@ -20,42 +20,30 @@ def test_ctor():
     sim2 = Simulator('test')
     assert sim1.atmosphere.airmass == sim2.atmosphere.airmass
 
+
 def test_alt_wavelengths():
-    import yaml
-    import pkg_resources
-    configfile = pkg_resources.resource_filename(
-        'specsim', 'data/config/test.yaml')
-    configdata = yaml.load(open(configfile))
-
-    # Test input 0.1 -> output 1.2 Angstrom wavelength grid
-    configdata['wavelength_grid']['step'] = 0.1
-    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '1.2 Angstrom'
-    config = specsim.config.Configuration(configdata)
+    config = specsim.config.load_config('test')
+    config.wavelength_grid.step = 0.1
+    config.instrument.cameras.r.constants.output_pixel_size = "1.2 Angstrom"
     sim = Simulator(config)
+    sim.simulate()
+    assert np.allclose(np.diff(sim.camera_output[0]['wavelength']), 1.2)
 
-    # Test input 0.1 -> output 0.6 Angstrom wavelength grid
-    configdata['wavelength_grid']['step'] = 0.1
-    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.6 Angstrom'
-    config = specsim.config.Configuration(configdata)
+    config.instrument.cameras.r.constants.output_pixel_size = "0.4 Angstrom"
     sim = Simulator(config)
+    sim.simulate()
+    assert np.allclose(np.diff(sim.camera_output[0]['wavelength']), 0.4)
 
-    # Test input 0.1 -> output 0.4 Angstrom wavelength grid
-    configdata['wavelength_grid']['step'] = 0.1
-    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.4 Angstrom'
-    config = specsim.config.Configuration(configdata)
+    config.instrument.cameras.r.constants.output_pixel_size = "0.3 Angstrom"
     sim = Simulator(config)
+    sim.simulate()
+    assert np.allclose(np.diff(sim.camera_output[0]['wavelength']), 0.3)
 
-    # Test input 0.1 -> output 0.3 Angstrom wavelength grid
-    configdata['wavelength_grid']['step'] = 0.1
-    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.3 Angstrom'
-    config = specsim.config.Configuration(configdata)
+    config.wavelength_grid.step = 0.2
+    config.instrument.cameras.r.constants.output_pixel_size = "0.2 Angstrom"
     sim = Simulator(config)
-
-    # Test input 0.2 -> output 0.2 Angstrom wavelength grid
-    configdata['wavelength_grid']['step'] = 0.2
-    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.2 Angstrom'
-    config = specsim.config.Configuration(configdata)
-    sim = Simulator(config)
+    sim.simulate()
+    assert np.allclose(np.diff(sim.camera_output[0]['wavelength']), 0.2)
 
 def test_end_to_end():
     sim = Simulator('test')

--- a/specsim/tests/test_simulator.py
+++ b/specsim/tests/test_simulator.py
@@ -27,17 +27,35 @@ def test_alt_wavelengths():
         'specsim', 'data/config/test.yaml')
     configdata = yaml.load(open(configfile))
 
-    # Create simulator with a 0.1 Angstrom simulation grid
+    # Test input 0.1 -> output 1.2 Angstrom wavelength grid
     configdata['wavelength_grid']['step'] = 0.1
-    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.1 Angstrom'
-    config1 = specsim.config.Configuration(configdata)
-    sim1 = Simulator(config1)
+    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '1.2 Angstrom'
+    config = specsim.config.Configuration(configdata)
+    sim = Simulator(config)
 
-    # Update to a 0.2 Angstrom step size and repeat
+    # Test input 0.1 -> output 0.6 Angstrom wavelength grid
+    configdata['wavelength_grid']['step'] = 0.1
+    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.6 Angstrom'
+    config = specsim.config.Configuration(configdata)
+    sim = Simulator(config)
+
+    # Test input 0.1 -> output 0.4 Angstrom wavelength grid
+    configdata['wavelength_grid']['step'] = 0.1
+    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.4 Angstrom'
+    config = specsim.config.Configuration(configdata)
+    sim = Simulator(config)
+
+    # Test input 0.1 -> output 0.3 Angstrom wavelength grid
+    configdata['wavelength_grid']['step'] = 0.1
+    configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.3 Angstrom'
+    config = specsim.config.Configuration(configdata)
+    sim = Simulator(config)
+
+    # Test input 0.2 -> output 0.2 Angstrom wavelength grid
     configdata['wavelength_grid']['step'] = 0.2
     configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.2 Angstrom'
-    config2 = specsim.config.Configuration(configdata)
-    sim2 = Simulator(config2)
+    config = specsim.config.Configuration(configdata)
+    sim = Simulator(config)
 
 def test_end_to_end():
     sim = Simulator('test')


### PR DESCRIPTION
Test driven development:  This PR provides a test that demonstrates a bug in calculating the `pixel_edges` vs. `sim_edges` for the wavelength binning.  My initial attempt at refactoring `int` vs. `round` vs. integer division just swapped what succeeded vs. failed, so I'm submitting this report with a test to get more eyes on it.

The test currently fails, but presumably we will find a fix and add that before merging this.  

```
============================================================================ FAILURES ============================================================================
______________________________________________________________________ test_alt_wavelengths ______________________________________________________________________

    def test_alt_wavelengths():
        import yaml
        import pkg_resources
        configfile = pkg_resources.resource_filename(
            'specsim', 'data/config/test.yaml')
        configdata = yaml.load(open(configfile))
    
        # Test input 0.1 -> output 1.2 Angstrom wavelength grid
        configdata['wavelength_grid']['step'] = 0.1
        configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '1.2 Angstrom'
        config = specsim.config.Configuration(configdata)
        sim = Simulator(config)
    
        # Test input 0.1 -> output 0.6 Angstrom wavelength grid
        configdata['wavelength_grid']['step'] = 0.1
        configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.6 Angstrom'
        config = specsim.config.Configuration(configdata)
        sim = Simulator(config)
    
        # Test input 0.1 -> output 0.4 Angstrom wavelength grid
        configdata['wavelength_grid']['step'] = 0.1
        configdata['instrument']['cameras']['r']['constants']['output_pixel_size'] = '0.4 Angstrom'
        config = specsim.config.Configuration(configdata)
>       sim = Simulator(config)

specsim/tests/test_simulator.py:46: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
specsim/simulator.py:66: in __init__
    self.instrument = specsim.instrument.initialize(config)
specsim/instrument.py:606: in initialize
    constants['num_sigmas_clip'], constants['output_pixel_size']))
specsim/camera.py:236: in __init__
    pixel_edges, sim_edges, rtol=0., atol=1e-6 * wavelength_step):
/Users/sbailey/anaconda/envs/desi/lib/python3.5/site-packages/numpy/core/numeric.py:2372: in allclose
    res = all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
/Users/sbailey/anaconda/envs/desi/lib/python3.5/site-packages/numpy/core/numeric.py:2453: in isclose
    return within_tol(x, y, atol, rtol)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

x = array([ 5599.95,  5600.35,  5600.75, ...,  7398.75,  7399.15,  7399.55]), y = array([ 5599.95,  5600.35,  5600.75, ...,  7399.15,  7399.55,  7399.95])
atol = 9.9999999999909045e-08, rtol = 0.0

    def within_tol(x, y, atol, rtol):
        with errstate(invalid='ignore'):
>           result = less_equal(abs(x-y), atol + rtol * abs(y))
E           ValueError: operands could not be broadcast together with shapes (4500,) (4501,)

/Users/sbailey/anaconda/envs/desi/lib/python3.5/site-packages/numpy/core/numeric.py:2436: ValueError
======================================================== 1 failed, 71 passed, 9 skipped in 22.91 seconds =========================================================
```