### PR TITLE
Add support for using a Simulator without per-camera outputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 - Add support for simulating calibration exposures (#54).
 - Add wavelength min/max options to Simulator.plot().
 - Better support for alternate simulation wavelength grids (PR #60).
+- Add Simulator option to not create and fill per-camera output tables (PR #67).
 
 0.8 (2017-03-25)
 ----------------

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -57,6 +57,12 @@ column has shape (nwlen) and the remaining columns all have shape
 | ``read_noise_electrons_*`` | RMS read noise in electrons for the CCD        |
 +----------------------------+------------------------------------------------+
 
+Note that the ``num_source_electrons_*`` and ``num_sky_electrons_*`` arrays are
+normally convolved with the appropriate camera resolution, but this convolution
+is not performed by a :class:`specsim.simulator.Simulator` initialized using the
+option ``camera_output = False``.  This can be useful when specsim is
+being used to calculate inputs to a more detailed pixel-level simulation.
+
 Camera Output Tables
 --------------------
 
@@ -65,6 +71,10 @@ The table below defines the columns of each table listed in
 The initial ``wavelength``
 column has shape (nwlen_out) and the remaining columns all have shape
 (nwlen_out, nfibers).
+
+These tables can require a lot of memory so, if they are not needed,
+initialize your :class:`specsim.simulator.Simulator` using the option
+``camera_output = False`` to save space and speed up simulations.
 
 +----------------------------+------------------------------------------------+
 | Column Name                | Description                                    |

--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -409,4 +409,6 @@ class Camera(object):
     def output_wavelength(self):
         """Output pixel central wavelengths.
         """
+        if not self.allow_convolution:
+            raise RuntimeError('Camera created with allow_convolution False.')
         return self._output_wavelength * self._wavelength_unit

--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -64,10 +64,15 @@ class Camera(object):
         Size of output pixels for this camera.  Units are required, e.g.
         Angstrom. Must be a multiple of the the spacing of the wavelength
         input parameter.
+    allow_convolution : bool
+        Set True to precompute the sparse resolution matrix needed by
+        :meth:`get_output_resolution_matrix`, :meth:`apply_resolution` and
+        :meth:`downsample`.
     """
     def __init__(self, name, wavelength, throughput, row_size,
                  fwhm_resolution, neff_spatial, read_noise, dark_current,
-                 gain, num_sigmas_clip, output_pixel_size):
+                 gain, num_sigmas_clip, output_pixel_size,
+                 allow_convolution=True):
         self.name = name
         self._wavelength = wavelength.to(self._wavelength_unit).value
         self.throughput = throughput
@@ -78,6 +83,7 @@ class Camera(object):
         self.dark_current = dark_current
         self.gain = gain
         self.num_sigmas_clip = num_sigmas_clip
+        self.allow_convolution = allow_convolution
 
         # The arrays defining the CCD properties must all have identical
         # wavelength coverage.
@@ -175,6 +181,11 @@ class Camera(object):
         column_size = column_stop - column_start
         assert np.all(column_size > 0)
 
+        # The remaining steps are only necessary to support convolution
+        # and downsampling.
+        if not self.allow_convolution:
+            return
+
         # Prepare start, stop values for slicing eval -> column.
         trim_start = column_start - eval_start
         trim_stop = column_stop - eval_start
@@ -251,7 +262,6 @@ class Camera(object):
             self.ccd_slice.start + num_downsampled * self._downsampling)
         self._downsampled_shape = (num_downsampled, self._downsampling)
 
-
     def get_output_resolution_matrix(self):
         """Return the output resolution matrix in DIA sparse format.
 
@@ -272,6 +282,8 @@ class Camera(object):
             Square array of resolution matrix elements in the DIA
             sparse format.
         """
+        if not self.allow_convolution:
+            raise RuntimeError('Camera created with allow_convolution False.')
         n = len(self._output_wavelength)
         m = self._downsampling
         i0 = self.ccd_slice.start - self.response_slice.start
@@ -320,10 +332,11 @@ class Camera(object):
         # Convert to DIA format and return.
         return R.todia()
 
-
     def downsample(self, data, method=np.sum):
         """Downsample data tabulated on the simulation grid to output pixels.
         """
+        if not self.allow_convolution:
+            raise RuntimeError('Camera created with allow_convolution False.')
         data = np.asanyarray(data)
         if data.shape[-1] != len(self._wavelength):
             raise ValueError(
@@ -333,13 +346,14 @@ class Camera(object):
         new_shape = output.shape[:-1] + self._downsampled_shape
         return method(output.reshape(new_shape), axis=-1)
 
-
     def apply_resolution(self, flux):
         """
         Input should be on the simulation wavelength grid.
 
         Any throughput should already be applied.
         """
+        if not self.allow_convolution:
+            raise RuntimeError('Camera created with allow_convolution False.')
         flux = np.asarray(flux)
         dispersed = np.zeros_like(flux)
 
@@ -348,10 +362,8 @@ class Camera(object):
 
         return dispersed
 
-
     # Canonical wavelength unit used for all internal arrays.
     _wavelength_unit = u.Angstrom
-
 
     @property
     def wavelength_min(self):
@@ -359,13 +371,11 @@ class Camera(object):
         """
         return self._wavelength_min * self._wavelength_unit
 
-
     @property
     def wavelength_max(self):
         """Maximum wavelength covered by this camera's CCD.
         """
         return self._wavelength_max * self._wavelength_unit
-
 
     @property
     def rms_resolution(self):
@@ -373,13 +383,11 @@ class Camera(object):
         """
         return self._rms_resolution * self._wavelength_unit
 
-
     @property
     def row_size(self):
         """Array of row sizes in the dispersion direction.
         """
         return self._row_size * self._wavelength_unit / u.pixel
-
 
     @property
     def neff_spatial(self):
@@ -387,15 +395,15 @@ class Camera(object):
         """
         return self._neff_spatial * u.pixel
 
-
     @property
     def output_pixel_size(self):
         """Size of output pixels.
 
         Must be a multiple of the simulation wavelength grid.
         """
+        if not self.allow_convolution:
+            raise RuntimeError('Camera created with allow_convolution False.')
         return self._output_pixel_size * self._wavelength_unit
-
 
     @property
     def output_wavelength(self):

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -32,10 +32,12 @@ class Instrument(object):
     """Model the instrument response of a fiber spectrograph.
 
     A spectrograph can have multiple :mod:`cameras <specsim.camera>` with
-    different wavelength coverages.
+    different wavelength coverages. Objects representing each camera are
+    contained in a list accessible from our ``cameras`` attribute, which will
+    be in order of increasing effective wavelength.
 
     No instrument attributes can be changed after an instrument has been
-    created. File a github issue if you would like to change this.
+    created. Create a github issue if you would like to change this.
 
     Parameters
     ----------

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -569,7 +569,7 @@ class Instrument(object):
         ax2.set_xlim(wave[0], wave[-1])
 
 
-def initialize(config):
+def initialize(config, camera_output=True):
     """Initialize the instrument model from configuration parameters.
 
     This method is responsible for creating a new :class:`Instrument` as
@@ -579,6 +579,9 @@ def initialize(config):
     ----------
     config : :class:`specsim.config.Configuration`
         The configuration parameters to use.
+    camera_output : bool
+        Initialize support for resolution convolution and downsampling for
+        each camera when True.
 
     Returns
     -------
@@ -603,7 +606,8 @@ def initialize(config):
             ccd['row_size'], ccd['fwhm_resolution'],
             ccd['neff_spatial'], constants['read_noise'],
             constants['dark_current'], constants['gain'],
-            constants['num_sigmas_clip'], constants['output_pixel_size']))
+            constants['num_sigmas_clip'], constants['output_pixel_size'],
+            allow_convolution=camera_output))
 
     constants = config.get_constants(
         config.instrument,

--- a/specsim/quickspecsim.py
+++ b/specsim/quickspecsim.py
@@ -92,7 +92,7 @@ def main(args=None):
 
     # Initialize the simulator.
     try:
-        simulator = specsim.simulator.Simulator(config)
+        simulator = specsim.simulator.Simulator(config, verbose=args.verbose)
     except RuntimeError as e:
         print(e)
         return -1

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -116,6 +116,12 @@ class Simulator(object):
             self._simulated.add_column(astropy.table.Column(
                 name='read_noise_electrons_{0}'.format(name), **column_args))
 
+        # Count the number of bytes used in the simulated table.
+        self.table_bytes = 0
+        for name in self._simulated.colnames:
+            d = self._simulated[name].data
+            self.table_bytes += np.prod(d.shape) * d.dtype.itemsize
+
         # Initialize each camera's table of results downsampled to
         # output pixels, if requested.
         self._camera_output = []
@@ -147,7 +153,16 @@ class Simulator(object):
                 table.add_column(astropy.table.Column(
                     name='flux_inverse_variance', unit=flux_unit ** -2,
                     **column_args))
+                # Add bytes used in this table to our running total.
+                for name in table.colnames:
+                    d = table[name].data
+                    self.table_bytes += np.prod(d.shape) * d.dtype.itemsize
+
                 self._camera_output.append(table)
+
+        if self.verbose:
+            print('Allocated {0:.1f}Mb of table data.'
+                  .format(self.table_bytes / (2. ** 20)))
 
     @property
     def num_fibers(self):

--- a/specsim/simulator.py
+++ b/specsim/simulator.py
@@ -53,8 +53,14 @@ class Simulator(object):
         A configuration object or configuration name.
     num_fibers : int
         Number of fibers to simulate.
+    camera_output : bool
+        Include per-camera output tables in simulation results when True.
+        Setting this parameter to False will save memory and time when
+        per-camera outputs are not needed.
+    verbose : bool
+        Print information about the simulation progress.
     """
-    def __init__(self, config, num_fibers=2, verbose=False):
+    def __init__(self, config, num_fibers=2, camera_output=True, verbose=False):
 
         if specsim.config.is_string(config):
             config = specsim.config.load_config(config)
@@ -63,7 +69,7 @@ class Simulator(object):
 
         # Initalize our component models.
         self.atmosphere = specsim.atmosphere.initialize(config)
-        self.instrument = specsim.instrument.initialize(config)
+        self.instrument = specsim.instrument.initialize(config, camera_output)
         self.source = specsim.source.initialize(config)
         self.observation = specsim.observation.initialize(config)
 
@@ -139,13 +145,11 @@ class Simulator(object):
                 **column_args))
             self._camera_output.append(table)
 
-
     @property
     def num_fibers(self):
         """Number of fibers being simulated.
         """
         return self._num_fibers
-
 
     @property
     def simulated(self):
@@ -158,7 +162,6 @@ class Simulator(object):
         """
         return self._simulated
 
-
     @property
     def camera_output(self):
         """list: List of per-camera simulation output tables.
@@ -169,7 +172,6 @@ class Simulator(object):
         of the contents of each table in this list.
         """
         return self._camera_output
-
 
     def simulate(self, sky_positions=None, focal_positions=None,
                  fiber_acceptance_fraction=None,
@@ -509,7 +511,6 @@ class Simulator(object):
             # Zero our random noise realization column.
             output['random_noise_electrons'][:] = 0.
 
-
     def generate_random_noise(self, random_state=None):
         """Generate a random noise realization for the most recent simulation.
 
@@ -545,7 +546,6 @@ class Simulator(object):
                 random_state.poisson(mean_electrons) - mean_electrons +
                 random_state.normal(scale=output['read_noise_electrons']))
 
-
     def save(self, filename, clobber=True):
         """Save results of the last simulation to a FITS file.
 
@@ -574,7 +574,6 @@ class Simulator(object):
         # Write the file.
         hdus.writeto(filename, clobber=clobber)
         hdus.close()
-
 
     def plot(self, fiber=0, wavelength_min=None, wavelength_max=None,
              title=None, min_electrons=2.5):

--- a/specsim/tests/test_camera.py
+++ b/specsim/tests/test_camera.py
@@ -61,3 +61,17 @@ def test_output_pixel_size():
     config.wavelength[10] += 0.001 * u.Angstrom
     with pytest.raises(RuntimeError):
         specsim.simulator.Simulator(config)
+
+
+def test_allow_convolution():
+    c = specsim.config.load_config('test')
+    i = specsim.instrument.initialize(c, camera_output=False)
+    camera = i.cameras[0]
+    with pytest.raises(RuntimeError):
+        camera.get_output_resolution_matrix()
+    with pytest.raises(RuntimeError):
+        camera.downsample(None)
+    with pytest.raises(RuntimeError):
+        camera.apply_resolution(None)
+    with pytest.raises(RuntimeError):
+        s = camera.output_pixel_size

--- a/specsim/tests/test_instrument.py
+++ b/specsim/tests/test_instrument.py
@@ -24,3 +24,9 @@ def test_distortion_plot():
     c = specsim.config.load_config('test')
     i = initialize(c)
     i.plot_field_distortion()
+
+
+def test_no_cameras():
+    c = specsim.config.load_config('test')
+    i = initialize(c, camera_output=False)
+    i.plot()

--- a/specsim/tests/test_simulator.py
+++ b/specsim/tests/test_simulator.py
@@ -130,3 +130,9 @@ def test_plot():
     s = Simulator('test')
     s.simulate()
     s.plot()
+
+
+def test_no_cameras():
+    s = Simulator('test', camera_output=False)
+    s.simulate()
+    s.plot()


### PR DESCRIPTION
This new mode is enabled via a new arg to the Simulator ctor:
```
    camera_output : bool
        Include per-camera output tables in simulation results when True.
        When this is False, our ``camera_output`` attribute will return an
        empty list and the ``num_source_electrons_*`` columns in our
        ``simulated`` table will not be resolution convolved.
        Setting this parameter to False will save memory and time when
        per-camera outputs are not needed.
```
Fixes #66.