### PR TITLE
Random uncorrelated offsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 -----------------
 
 - Implement fast fiberloss calculator that interpolates GalSim results (#78).
+- Add uncorrelated random offsets (#81)
 
 0.10 (2017-10-03)
 -----------------

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -161,12 +161,29 @@ instrument:
         path: throughput/DESI-0347_offset.ecsv
         # The ECSV format is not auto-detected so we specify it explicitly.
         format: ascii.ecsv
-        # Read random achromatic centroid offsets from a FITS file.
+        #
+        # static/stable achromatic but correlated centroid offsets from a FITS file
+        # this is to emulate any systematic residual of the plate maker
+        # in particular the effect of the corrector lens
+        # polishing errors (see DESI-1071)
+        # DESI-0347_random_offset_*.fits is the worst case scenario where
+        # we cannot correct for this during commissionning
         # Uncomment any one of these lines to select a different random set.
-        # No random offsets are applied if all lines are commented out.
-        random: throughput/DESI-0347_random_offset_1.fits
-        #random: throughput/DESI-0347_random_offset_2.fits
-        #random: throughput/DESI-0347_random_offset_3.fits
+        # If all lines are commented out, this effect is ignored
+        #static: throughput/DESI-0347_random_offset_1.fits
+        #static: throughput/DESI-0347_random_offset_2.fits
+        #static: throughput/DESI-0347_random_offset_3.fits
+        #
+        # random achromatic and uncorrelated offsets with 1D rms = sigma1d
+        # ( per axis, i.e. sqrt(mean(dx**2+dy**2))=sqrt(2)*sigma1d )
+        # this is to emulate an uncorrelated positionner, astrometric, ... errors
+        # see lateral error in DESI-347 which is the throughput budget spreadsheet
+        #
+        # in DESI-347-v11 the quadratic sum of all lateral error terms except
+        # 'Band-limited chromatic shift microns' (already included in radial centroid offsets)
+        # and 'FVC corrector optics figure error' (a static term)
+        # is 7.26 um = 5.1 * sqrt(2) um
+        sigma1d: 5.1 um
     cameras:
         b:
             constants:


### PR DESCRIPTION
Add uncorrelated random offsets in instrument.py and config file
 - Add keyword ```instrument.offset.sigma1d``` in ```desi.yaml``` configuration file. Default value of 5.1 um is  1/sqrt(2) of quadratic sum of all contributions to lateral shift in DESI-347-v11 excluding  the 'Band-limited chromatic shift' (already included in radial centroid offsets) and 'FVC corrector optics figure error' (because this is mostly static)
 - Rename ```instrument.offset.random``` keyword to ```instrument.offset.static``` because it emulates the effect of the corrector lens polishing errors (see DESI-1071), which is mostly static/stable.
 - Comment out ```instrument.offset.static``` in default configuration because we should hope that a large fraction of this effect will be calibrated and corrected during commissioning. We will change this when a more precise model of lateral shifts becomes available (for the moment, some contributions are missing:  atmospheric jitter, telescope guiding/tracking errors, knowledge of static telescope optical distortion, truss and telescope lateral thermal drift, and the others are not very well known).
