### PR TITLE
Fix matplotlib errors when no $DISPLAY

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,13 +92,11 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.8
-        - os: linux
-          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
-        - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
         - os: linux
-          env: NUMPY_VERSION=1.11
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
+        - os: linux
+          env: NUMPY_VERSION=1.12
 
         # Try numpy pre-release
         - os: linux
@@ -107,13 +105,13 @@ matrix:
 
         # Do a PEP8 test with pycodestyle
         - os: linux
-          env: MAIN_CMD='pycodestyle packagename --count' SETUP_CMD=''
+          env: MAIN_CMD='pycodestyle specsim --count' SETUP_CMD=''
 
     allow_failures:
         # Do a PEP8 test with pycodestyle
         # (allow to fail unless your code completely compliant)
         - os: linux
-          env: MAIN_CMD='pycodestyle packagename --count' SETUP_CMD=''
+          env: MAIN_CMD='pycodestyle specsim --count' SETUP_CMD=''
 
 install:
 
@@ -128,8 +126,8 @@ install:
     # in how to install a package, in which case you can have additional
     # commands in the install: section below.
 
-    - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda.sh
 
     # As described above, using ci-helpers, you should be able to set up an
     # environment with dependencies installed using conda and pip, but in some

--- a/specsim/atmosphere.py
+++ b/specsim/atmosphere.py
@@ -26,7 +26,7 @@ An atmosphere model is usually initialized from a configuration used to create
 a simulator and then accessible via its ``atmosphere`` attribute, for example:
 
     >>> import specsim.simulator
-    >>> simulator = specsim.simulator.Simulator('test')
+    >>> simulator = specsim.simulator.Simulator('test')  # doctest: +IGNORE_OUTPUT
     >>> simulator.atmosphere.airmass
     1.0
 

--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -7,7 +7,7 @@ a simulator and then accessible via its ``instrument.cameras`` attribute,
 for example:
 
     >>> import specsim.simulator
-    >>> simulator = specsim.simulator.Simulator('test')
+    >>> simulator = specsim.simulator.Simulator('test')  # doctest: +IGNORE_OUTPUT
     >>> print(np.round(simulator.instrument.cameras[0].read_noise, 1))
     2.9 electron / pix2
 

--- a/specsim/fitgalsim.py
+++ b/specsim/fitgalsim.py
@@ -15,8 +15,6 @@ import numpy as np
 import astropy.table
 import astropy.units as u
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
-import time
 
 import specsim.simulator
 import specsim.fiberloss

--- a/specsim/instrument.py
+++ b/specsim/instrument.py
@@ -5,7 +5,7 @@ An instrument model is usually initialized from a configuration used to create
 a simulator and then accessible via its ``instrument`` attribute, for example:
 
     >>> import specsim.simulator
-    >>> simulator = specsim.simulator.Simulator('test')
+    >>> simulator = specsim.simulator.Simulator('test')  # doctest: +IGNORE_OUTPUT
     >>> print(np.round(simulator.instrument.fiber_diameter, 1))
     107.0 um
 

--- a/specsim/observation.py
+++ b/specsim/observation.py
@@ -5,7 +5,7 @@ An observation is usually initialized from a configuration used to create
 a simulator and then accessible via its ``observation`` attribute, for example:
 
     >>> import specsim.simulator
-    >>> simulator = specsim.simulator.Simulator('test')
+    >>> simulator = specsim.simulator.Simulator('test')  # doctest: +IGNORE_OUTPUT
     >>> print(simulator.observation.exposure_time)
     1000.0 s
 

--- a/specsim/source.py
+++ b/specsim/source.py
@@ -5,7 +5,7 @@ An source model is usually initialized from a configuration used to create
 a simulator and then accessible via its ``source`` attribute, for example:
 
     >>> import specsim.simulator
-    >>> simulator = specsim.simulator.Simulator('test')
+    >>> simulator = specsim.simulator.Simulator('test')  # doctest: +IGNORE_OUTPUT
     >>> print(simulator.source.name)
     Constant flux density test source
 


### PR DESCRIPTION
As reported by @sbailey, when running `python setup.py test` with astropy 2.x and with the `$DISPLAY` variable *unset*, multiple errors were reported.  The cause turned out to be in fitgalsim.py, which imported matplotlib at the top level, without setting `matplotlib.use('Agg')`.

It turns out that fitgalsim.py does not actually use matplotlib at all, so the solution was to remove the import entirely.

Technical note:  The reason this is a problem in astropy 2.x is that astropy 2.x scans (imports) *all* files for tests (specifically doctests), not just the `specsim/tests/test_*.py` files.