### PR TITLE
support astropy4 units check in test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='scipy pyyaml matplotlib'
+        - CONDA_DEPENDENCIES='scipy pyyaml matplotlib pytest-astropy'
 
         # Conda packages for affiliated packages are hosted in channel
         # "astropy" while builds for astropy LTS with recent numpy versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,9 @@ env:
 
     matrix:
         # Make sure that egg_info works without dependencies
-        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.8 SETUP_CMD='egg_info'
 
 matrix:
 
@@ -76,12 +76,12 @@ matrix:
         - os: linux
           env: SETUP_CMD='build_docs -w'
 
-        # Now try Astropy dev and LTS vesions with the latest 3.x and 2.7.
+        # Now try Astropy dev and LTS vesions with the latest 3.x
         - os: linux
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
         - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts
+          env: PYTHON_VERSION=3.8 ASTROPY_VERSION=lts
         - os: linux
           env: ASTROPY_VERSION=lts
 
@@ -91,9 +91,9 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.13
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.16
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.14
+          env: PYTHON_VERSION=3.8 NUMPY_VERSION=1.18
 
         # Try numpy pre-release
         - os: linux

--- a/specsim/tests/test_source.py
+++ b/specsim/tests/test_source.py
@@ -19,7 +19,7 @@ def test_ctor():
     assert src.wavelength_in.unit == u.Angstrom
     assert src.flux_in.unit == u.erg / (u.cm ** 2 * u.s * u.Angstrom)
 
-    assert np.array_equal(src.wavelength_out.value, config.wavelength)
+    assert np.array_equal(src.wavelength_out.value, config.wavelength.value)
     assert np.all(src.flux_out.value == 1e-17)
     assert src.flux_out.unit == src.flux_in.unit
 


### PR DESCRIPTION
This PR is a one-line six-character change to support unit tests on astropy 4.  With astropy 2, comparing a unit-full astropy Quantity array with a unit-less numpy array was apparently ok, but now generates a dizzying traceback of exceptions within exceptions within exceptions that basically boil down to a units mis-match.  This PR fixes that.

At the same time, based upon the other dangling PRs we may need to do some Travis config updates to get this to pass on Travis.