### PR TITLE
Fix deg. to rad. bug in scattering function of KS. 

### DIFF
--- a/specsim/atmosphere.py
+++ b/specsim/atmosphere.py
@@ -583,7 +583,7 @@ def krisciunas_schaefer(obs_zenith, moon_zenith, separation_angle, moon_phase,
     Istar = 10 ** (-0.4 * (m + 16.57))
     # Calculate the scattering function (eqn.21).
     rho = separation_angle.to(u.deg).value
-    f_scatter = (10 ** 5.36 * (1.06 + np.cos(separation_angle) ** 2) +
+    f_scatter = (10 ** 5.36 * (1.06 + np.cos(separation_angle * np.pi / 180.) ** 2) +
                  10 ** (6.15 - rho / 40.))
     # Calculate the scattering airmass along the lines of sight to the
     # observation and moon (eqn. 3).


### PR DESCRIPTION
I implemented an independent KS and compared it to specsim.  For the scattering fn., I find this:

![image](https://user-images.githubusercontent.com/6034066/104255577-3f2bdc80-542e-11eb-9981-63520cba275c.png)

Orig: Specsim, fix: change I'm proposing. MJW: my implementation. 

The source of the difference is a lack of conv. from deg. to rad. in a call to np.cos here: https://github.com/desihub/specsim/blob/56e203f1ca0bd606390da351ac9d6b207c6bed08/specsim/atmosphere.py#L586
The scattering eqn. is a little strange as it uses rho in two different units for the Rayleigh & Mie parts, where the cos term uses radians and the additive term uses degrees.  

Original KS Fig. 1:
![image](https://user-images.githubusercontent.com/6034066/104255613-5074e900-542e-11eb-9935-abe6d80f8aff.png)

Comparison to Connie's original IDL confirms the conversion was lost (https://desi.lbl.gov/svn/code/desimodel/tags/0.4.2/pro/lunarmodel.pro), IDL:
fp=10^(5.36)*(1.06+cos(sepang*!pi/180.)^2)+10^(6.15-sepang/40.)
