### PR TITLE
Make compatible with astropy 4.3

### DIFF
--- a/specsim/config.py
+++ b/specsim/config.py
@@ -43,6 +43,13 @@ import astropy.time
 import astropy.io.fits
 import astropy.wcs
 
+from astropy.utils.introspection import minversion
+ASTROPY_LT_4_3 = not minversion(astropy, '4.3')
+
+if ASTROPY_LT_4_3:
+    from astropy.utils.data import _find_pkg_data_path as get_pkg_data_path
+else:
+    from astropy.utils.data import get_pkg_data_path
 
 def is_string(x):
     """Test if x is a string type.
@@ -238,7 +245,7 @@ class Configuration(Node):
         base_path = self.base_path
         if base_path == '<PACKAGE_DATA>':
             self._assign(
-                'abs_base_path', astropy.utils.data._find_pkg_data_path('data'))
+                'abs_base_path', get_pkg_data_path('data'))
         else:
             try:
                 self._assign('abs_base_path', base_path.format(**os.environ))
@@ -686,7 +693,7 @@ def load_config(name, config_type=Configuration):
     if extension:
         file_name = name
     else:
-        file_name = astropy.utils.data._find_pkg_data_path(
+        file_name = get_pkg_data_path(
             'data/config/{0}.yaml'.format(name))
     if not os.path.isfile(file_name):
         raise ValueError('No such config file "{0}".'.format(file_name))

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -37,19 +37,12 @@ import scipy.interpolate
 
 import astropy.units
 import astropy.table
-import astropy.utils.data
 import astropy.coordinates
 import astropy.time
 import astropy.io.fits
 import astropy.wcs
 
-from astropy.utils.introspection import minversion
-ASTROPY_LT_4_3 = not minversion(astropy, '4.3')
-
-if ASTROPY_LT_4_3:
-    from astropy.utils.data import _find_pkg_data_path as get_pkg_data_path
-else:
-    from astropy.utils.data import get_pkg_data_path
+import pkg_resources
 
 def is_string(x):
     """Test if x is a string type.
@@ -245,7 +238,7 @@ class Configuration(Node):
         base_path = self.base_path
         if base_path == '<PACKAGE_DATA>':
             self._assign(
-                'abs_base_path', get_pkg_data_path('data'))
+                'abs_base_path', pkg_resources.resource_filename('specsim','data'))
         else:
             try:
                 self._assign('abs_base_path', base_path.format(**os.environ))
@@ -693,8 +686,7 @@ def load_config(name, config_type=Configuration):
     if extension:
         file_name = name
     else:
-        file_name = get_pkg_data_path(
-            'data/config/{0}.yaml'.format(name))
+        file_name  = pkg_resources.resource_filename('specsim','data/config/{0}.yaml'.format(name))
     if not os.path.isfile(file_name):
         raise ValueError('No such config file "{0}".'.format(file_name))
 

--- a/specsim/config.py
+++ b/specsim/config.py
@@ -42,7 +42,7 @@ import astropy.time
 import astropy.io.fits
 import astropy.wcs
 
-import pkg_resources
+from pkg_resources import resource_filename
 
 def is_string(x):
     """Test if x is a string type.
@@ -238,7 +238,7 @@ class Configuration(Node):
         base_path = self.base_path
         if base_path == '<PACKAGE_DATA>':
             self._assign(
-                'abs_base_path', pkg_resources.resource_filename('specsim','data'))
+                'abs_base_path', resource_filename('specsim','data'))
         else:
             try:
                 self._assign('abs_base_path', base_path.format(**os.environ))
@@ -686,7 +686,8 @@ def load_config(name, config_type=Configuration):
     if extension:
         file_name = name
     else:
-        file_name  = pkg_resources.resource_filename('specsim','data/config/{0}.yaml'.format(name))
+        file_name  = resource_filename('specsim',
+                                       'data/config/{0}.yaml'.format(name))
     if not os.path.isfile(file_name):
         raise ValueError('No such config file "{0}".'.format(file_name))
 


### PR DESCRIPTION
Fixes #116  by using `pkg_resources.resource_filename` instead of `astropy.utils.data._find_pkg_data_path`, which does not work for astropy >= 4.3. Thanks to @weaverba137 for pointing out a [previous solution](https://github.com/desihub/speclite/pull/68/files), on which this modification is based.

This branch passes all unit tests on Cori for astropy versions 4.0.1.post1 and 4.3.1. Please review and merge if appropriate. 