### PR TITLE
Reproduce the wavelength array in observed data.

### DIFF
--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -247,8 +247,8 @@ class Camera(object):
         # The self._wavelength array stores the centers of fixed-width bins.
         # Calculate the edges of the downsampled output pixels. Trim
         # any partial output pixel on the high end.
-        output_min = self._wavelength_min - 0.5 * wavelength_step
-        output_max = self._wavelength_max + 0.5 * wavelength_step
+        output_min = self._wavelength_min   # output_min should match self._wavelength_min
+        output_max = self._wavelength_max   # output_max should match self._wavelength_max
         num_downsampled = int(np.floor(
             (output_max - output_min) / self._output_pixel_size))
         pixel_edges = (

--- a/specsim/camera.py
+++ b/specsim/camera.py
@@ -247,15 +247,15 @@ class Camera(object):
         # The self._wavelength array stores the centers of fixed-width bins.
         # Calculate the edges of the downsampled output pixels. Trim
         # any partial output pixel on the high end.
-        output_min = self._wavelength_min   # output_min should match self._wavelength_min
-        output_max = self._wavelength_max   # output_max should match self._wavelength_max
+        output_min = self._wavelength_min - 0.5 * wavelength_step
+        output_max = self._wavelength_max + 0.5 * wavelength_step
         num_downsampled = int(np.floor(
             (output_max - output_min) / self._output_pixel_size))
         pixel_edges = (
             output_min +
             np.arange(num_downsampled + 1) * self._output_pixel_size)
-        # Save the centers of each output pixel.
-        self._output_wavelength = 0.5 * (pixel_edges[1:] + pixel_edges[:-1])
+        # Save the centers shifted by 0.1 of each output pixel. Shift introduced to reproduce observed wavelenght array.
+        self._output_wavelength = 0.5 * (pixel_edges[1:] + pixel_edges[:-1]) + 0.1
         # Initialize the parameters used by the downsample() method.
         self._output_slice = slice(
             self.ccd_slice.start,

--- a/specsim/data/config/desi.yaml
+++ b/specsim/data/config/desi.yaml
@@ -206,7 +206,7 @@ instrument:
                 output_pixel_size: 0.5 Angstrom
             ccd:
                 table:
-                    path: specpsf/psf-quicksim.fits
+                    path: specpsf/psf-quicksim-y1.fits
                     hdu: QUICKSIM-B
                     extrapolated_value: 0.0
                     columns:
@@ -243,7 +243,7 @@ instrument:
                 output_pixel_size: 0.5 Angstrom
             ccd:
                 table:
-                    path: specpsf/psf-quicksim.fits
+                    path: specpsf/psf-quicksim-y1.fits
                     hdu: QUICKSIM-R
                     extrapolated_value: 0.0
                     columns:
@@ -280,7 +280,7 @@ instrument:
                 output_pixel_size: 0.5 Angstrom
             ccd:
                 table:
-                    path: specpsf/psf-quicksim.fits
+                    path: specpsf/psf-quicksim-y1.fits
                     hdu: QUICKSIM-Z
                     extrapolated_value: 0.0
                     columns:


### PR DESCRIPTION
Changes required to reproduce the wavelength array in observed data.
 
One of the changes is to change the file $DESIMODEL/data/specpsf/psf-quicksim.fits for a modified version $DESIMODEL/data/specpsf/psf-quicksim-y1.fits, so that the minimum and maximum wavelength for each band correspond to the corresponding ones in the observed data. 

@dkirkby  would you agree on these modifications so that we are able to have the same wavelength arrays in our simulated spectra with quickquasars than in the data? 

I'm setting the PR as draft in case there is much discussion on how to proceed. 