### PR TITLE
Fix unittest errors on astropy >= 5.1

### DIFF
--- a/specsim/conftest.py
+++ b/specsim/conftest.py
@@ -7,29 +7,15 @@ if astropy_version < '3.0':
     # With older versions of Astropy, we actually need to import the pytest
     # plugins themselves in order to make them discoverable by pytest.
     from astropy.tests.pytest_plugins import *
-else:
-    # As of Astropy 3.0, the pytest plugins provided by Astropy are
-    # automatically made available when Astropy is installed. This means it's
-    # not necessary to import them here, but we still need to import global
-    # variables that are used for configuration.
-    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+    
+# As of Astropy 5.1 astropy.tests.plugins.display (where PYTEST_HEADER_MODULES
+# and TESTED_VERSIONS lived) as been deprecated and removed entirely. 
 
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions
 # enable_deprecations_as_exceptions()
-
-## Uncomment and customize the following lines to add/remove entries from
-## the list of packages for which version numbers are displayed when running
-## the tests. Making it pass for KeyError is essential in some cases when
-## the package uses other astropy affiliated packages.
-# try:
-#     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-#     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
-#     del PYTEST_HEADER_MODULES['h5py']
-# except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
-#     pass
 
 ## Uncomment the following lines to display the version number of the
 ## package rather than the version number of Astropy in the top line when

--- a/specsim/conftest.py
+++ b/specsim/conftest.py
@@ -11,10 +11,10 @@ if astropy_version < '3.0':
 # As of Astropy 5.1 astropy.tests.plugins.display (where PYTEST_HEADER_MODULES
 # and TESTED_VERSIONS lived) as been deprecated and removed entirely. 
 
-from astropy.tests.helper import enable_deprecations_as_exceptions
-
-## Uncomment the following line to treat all DeprecationWarnings as
+## Uncomment the following lines to treat all DeprecationWarnings as
 ## exceptions
+## Note that this is deprecated as of Astropy 5.1 and may be removed in the future
+# from astropy.tests.helper import enable_deprecations_as_exceptions
 # enable_deprecations_as_exceptions()
 
 ## Uncomment the following lines to display the version number of the

--- a/specsim/tests/test_observation.py
+++ b/specsim/tests/test_observation.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import pytest
 
 from ..observation import *
 from ..instrument import initialize as instrument_init

--- a/specsim/tests/test_transform.py
+++ b/specsim/tests/test_transform.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import pytest
 from ..transform import altaz_to_focalplane, focalplane_to_altaz, \
     observatories, create_observing_model, sky_to_altaz, altaz_to_sky, \
     adjust_time_to_hour_angle, low_altitude_threshold
@@ -122,7 +122,7 @@ def test_invalid_frame():
         altaz_to_sky(0.5*u.rad, 1.5*u.rad, obs_model, frame='invalid')
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_alt_no_warn():
     where = observatories['APO']
     when = Time(56383, format='mjd')
@@ -136,7 +136,7 @@ def test_alt_no_warn():
     altaz_to_sky(low_altitude_threshold - 1*u.deg, 0*u.deg, obs_model)
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_alt_no_warn_pressure_array():
     where = observatories['APO']
     when = Time(56383, format='mjd')
@@ -188,7 +188,7 @@ def test_alt_warn_pressure_array():
         print(altaz_to_sky(alt[:, np.newaxis], 0*u.deg, obs_model).shape)
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_altaz_roundtrip():
     where = observatories['APO']
     when = Time(56383, format='mjd')
@@ -204,7 +204,7 @@ def test_altaz_roundtrip():
     assert np.allclose(sky_in.dec.to(u.rad).value, sky_out.dec.to(u.rad).value)
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_altaz_array_roundtrip():
     where = observatories['APO']
     when = Time(56383, format='mjd')
@@ -220,7 +220,7 @@ def test_altaz_array_roundtrip():
     assert np.all(np.abs(altaz_out.az - az_in) < 1e-5 * u.arcsec)
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_sky_to_altaz_shape():
     where = observatories['APO']
     when = Time(56383, format='mjd')
@@ -250,7 +250,7 @@ def test_sky_to_altaz_shape():
         obs_model).shape == (3, 3, 2)
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_altaz_to_sky_shape():
     where = observatories['APO']
     when = Time(56383, format='mjd')
@@ -279,7 +279,7 @@ def test_altaz_to_sky_shape():
         obs_model).shape == (3, 3, 2)
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_adjust_null():
     ra = 45 * u.deg
     when = Time(56383, format='mjd', location=observatories['APO'])
@@ -295,14 +295,14 @@ def test_adjust_missing_longitude():
         adjusted = adjust_time_to_hour_angle(when, ra, 0. * u.deg)
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_adjust_future():
     ra = 45 * u.deg
     when = Time(58000, format='mjd', location=observatories['APO'])
     adjusted = adjust_time_to_hour_angle(when, ra, 0. * u.deg)
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_zero_hour_angle_adjust():
     where = observatories['KPNO']
     when = Time('2013-01-01 00:00:00', format='iso', location=where)


### PR DESCRIPTION
This short PR performs four small tasks that allow specsim's unit tests to run on astropy versions >= 5.1, fixing #123:

1. Comments out (but does not remove) the unused and currently deprecated  and marked for future removal `from astropy.tests.helper import enable_deprecations_as_exceptions` from `conftest.py`
2. Removes `from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS` and associated commented out code from `conftest.py`
3. Removes `from astropy.tests.helper import remote_data` from `test_observations.py` (where it was unused) and `test_transform.py`
4. Replaces `@remote_data` with the recommended replacement `@pytest.mark.remote_data` in `test_transform.py`

These changes were necessitated from [the changelog for astropy v5.1](https://docs.astropy.org/en/v5.2.1/changelog.html#astropy-tests)

There are no functional changes to the main body code of specsim, and the changes are confirmed backwards compatible with astropy 5.0.1.